### PR TITLE
feat: `Sidequest.build` from job

### DIFF
--- a/.github/workflows/validate-branch.yml
+++ b/.github/workflows/validate-branch.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Validate branch name
         run: |
-          BRANCH_NAME="${{ github.head_ref }}"
+          BRANCH_NAME=$(printf "%s" "${{ github.head_ref }}")
           echo "Branch name: $BRANCH_NAME"
           if [[ ! "$BRANCH_NAME" =~ ^(feat|fix|chore|docs|refactor|style|test|tests|perf|build)/.+$ ]]; then
             echo "::error::Invalid branch name: '$BRANCH_NAME'."
@@ -24,7 +24,7 @@ jobs:
 
       - name: Validate PR title
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE=$(printf "%s" "${{ github.event.pull_request.title }}")
           echo "PR title: $PR_TITLE"
           if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|style|test|tests|perf|build)(\(.+\))?:\ .+ ]]; then
             echo "::error::Invalid PR title: $PR_TITLE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,84 +1,73 @@
 # [1.0.0-next.14](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.13...v1.0.0-next.14) (2025-07-25)
 
-
 ### Features
 
-* recurring jobs ([#12](https://github.com/sidequestjs/sidequest/issues/12)) ([cd66663](https://github.com/sidequestjs/sidequest/commit/cd6666318fb1786e09354954c39cc76ed24c11b5))
+- recurring jobs ([#12](https://github.com/sidequestjs/sidequest/issues/12)) ([cd66663](https://github.com/sidequestjs/sidequest/commit/cd6666318fb1786e09354954c39cc76ed24c11b5))
 
 # [1.0.0-next.13](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.12...v1.0.0-next.13) (2025-07-25)
 
-
 ### Features
 
-* enhance queue management with defaults and force update options ([#5](https://github.com/sidequestjs/sidequest/issues/5)) ([40acbec](https://github.com/sidequestjs/sidequest/commit/40acbec8386627f90b29de9dd4937610d4153dbe))
+- enhance queue management with defaults and force update options ([#5](https://github.com/sidequestjs/sidequest/issues/5)) ([40acbec](https://github.com/sidequestjs/sidequest/commit/40acbec8386627f90b29de9dd4937610d4153dbe))
 
 # [1.0.0-next.12](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.11...v1.0.0-next.12) (2025-07-24)
 
-
 ### Bug Fixes
 
-* update jobDefaults handling and add engine tests ([#4](https://github.com/sidequestjs/sidequest/issues/4)) ([bbd8dde](https://github.com/sidequestjs/sidequest/commit/bbd8dde20315a2092e979cc48b58646136eeee73))
+- update jobDefaults handling and add engine tests ([#4](https://github.com/sidequestjs/sidequest/issues/4)) ([bbd8dde](https://github.com/sidequestjs/sidequest/commit/bbd8dde20315a2092e979cc48b58646136eeee73))
 
 # [1.0.0-next.11](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.10...v1.0.0-next.11) (2025-07-24)
 
-
 ### Bug Fixes
 
-* including migrations on backends ([a670e89](https://github.com/sidequestjs/sidequest/commit/a670e89263f20eff9ad5156b997ecb6f6a9069f2))
+- including migrations on backends ([a670e89](https://github.com/sidequestjs/sidequest/commit/a670e89263f20eff9ad5156b997ecb6f6a9069f2))
 
 # [1.0.0-next.10](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.9...v1.0.0-next.10) (2025-07-24)
 
-
 ### Bug Fixes
 
-* release next ([66b9329](https://github.com/sidequestjs/sidequest/commit/66b9329c59b17696a10d91f3854c327361bbf1b6))
+- release next ([66b9329](https://github.com/sidequestjs/sidequest/commit/66b9329c59b17696a10d91f3854c327361bbf1b6))
 
 # [1.0.0-next.9](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.8...v1.0.0-next.9) (2025-07-24)
 
-
 ### Bug Fixes
 
-* release next ([dd9f2af](https://github.com/sidequestjs/sidequest/commit/dd9f2afcc03de79fbb9f70ab83db5191b9dff903))
-* removing version from monorepo ([e4c5a76](https://github.com/sidequestjs/sidequest/commit/e4c5a76a300ddddf3c8f369bef5e1c24e15a46ee))
+- release next ([dd9f2af](https://github.com/sidequestjs/sidequest/commit/dd9f2afcc03de79fbb9f70ab83db5191b9dff903))
+- removing version from monorepo ([e4c5a76](https://github.com/sidequestjs/sidequest/commit/e4c5a76a300ddddf3c8f369bef5e1c24e15a46ee))
 
 # [1.0.0-next.9](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.8...v1.0.0-next.9) (2025-07-24)
 
-
 ### Bug Fixes
 
-* release next ([dd9f2af](https://github.com/sidequestjs/sidequest/commit/dd9f2afcc03de79fbb9f70ab83db5191b9dff903))
+- release next ([dd9f2af](https://github.com/sidequestjs/sidequest/commit/dd9f2afcc03de79fbb9f70ab83db5191b9dff903))
 
 # [1.0.0-next.8](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.7...v1.0.0-next.8) (2025-07-24)
 
-
 ### Bug Fixes
 
-* release next ([cc4b2bd](https://github.com/sidequestjs/sidequest/commit/cc4b2bdc5800212a9930456ccd9827c4d1488263))
-* versions ([903c601](https://github.com/sidequestjs/sidequest/commit/903c60132fd6d28ede4ef66e505cdbf1667bf24f))
+- release next ([cc4b2bd](https://github.com/sidequestjs/sidequest/commit/cc4b2bdc5800212a9930456ccd9827c4d1488263))
+- versions ([903c601](https://github.com/sidequestjs/sidequest/commit/903c60132fd6d28ede4ef66e505cdbf1667bf24f))
 
 # [1.0.0-next.7](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.6...v1.0.0-next.7) (2025-07-24)
 
-
 ### Bug Fixes
 
-* remove topological ([f25b881](https://github.com/sidequestjs/sidequest/commit/f25b881db0fca3e01db3a4c1ab7b4d0eeecb8e8d))
-* removing version script ([e7736a4](https://github.com/sidequestjs/sidequest/commit/e7736a4bff01785d82ad3d2098f7b7cf6fe7d6da))
-* versions ([abd5a80](https://github.com/sidequestjs/sidequest/commit/abd5a80c7eaed20c8257af9c3323db445c50a066))
-* yarn lock ([d9cdc68](https://github.com/sidequestjs/sidequest/commit/d9cdc68ad126934e0e6c041fcc3a59c5dd64715f))
+- remove topological ([f25b881](https://github.com/sidequestjs/sidequest/commit/f25b881db0fca3e01db3a4c1ab7b4d0eeecb8e8d))
+- removing version script ([e7736a4](https://github.com/sidequestjs/sidequest/commit/e7736a4bff01785d82ad3d2098f7b7cf6fe7d6da))
+- versions ([abd5a80](https://github.com/sidequestjs/sidequest/commit/abd5a80c7eaed20c8257af9c3323db445c50a066))
+- yarn lock ([d9cdc68](https://github.com/sidequestjs/sidequest/commit/d9cdc68ad126934e0e6c041fcc3a59c5dd64715f))
 
 # [1.0.0-next.6](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.5...v1.0.0-next.6) (2025-07-24)
 
-
 ### Bug Fixes
 
-* publish ([17d036b](https://github.com/sidequestjs/sidequest/commit/17d036b42daba62750d2eca02f149605f134089a))
+- publish ([17d036b](https://github.com/sidequestjs/sidequest/commit/17d036b42daba62750d2eca02f149605f134089a))
 
 # [1.0.0-next.5](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.4...v1.0.0-next.5) (2025-07-24)
 
-
 ### Bug Fixes
 
-* release next ([586ec83](https://github.com/sidequestjs/sidequest/commit/586ec832cd207af09e2da4ca61d1cf1a9013ea20))
+- release next ([586ec83](https://github.com/sidequestjs/sidequest/commit/586ec832cd207af09e2da4ca61d1cf1a9013ea20))
 
 # [1.0.0-next.4](https://github.com/sidequestjs/sidequest/compare/v1.0.0-next.3...v1.0.0-next.4) (2025-07-24)
 

--- a/packages/backends/backend/src/index.ts
+++ b/packages/backends/backend/src/index.ts
@@ -2,5 +2,6 @@ export * from "./backend";
 export * from "./config";
 export * from "./constants";
 export * from "./factory";
+export * from "./lazy-backend";
 export * from "./sql-backend";
 export * from "./utils";

--- a/packages/backends/backend/src/lazy-backend.test.ts
+++ b/packages/backends/backend/src/lazy-backend.test.ts
@@ -43,11 +43,11 @@ describe("LazyBackend", () => {
   });
 
   it("should lazily initialize backend on first use", async () => {
-    // @ts-expect-error this exists
+    // @ts-expect-error Accessing private 'backend' property for testing lazy initialization behavior
     expect(lazyBackend.backend).toBeUndefined();
     await lazyBackend.migrate();
     expect(createBackendFromDriver).toHaveBeenCalledWith(config);
-    // @ts-expect-error this exists
+    // @ts-expect-error Accessing private 'backend' property for testing lazy initialization behavior
     expect(lazyBackend.backend).toBe(mockBackend);
   });
 

--- a/packages/backends/backend/src/lazy-backend.test.ts
+++ b/packages/backends/backend/src/lazy-backend.test.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { JobData, QueueConfig } from "@sidequest/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Backend, JobCounts, NewJobData, NewQueueData, UpdateJobData, UpdateQueueData } from "./backend";
+import { BackendConfig } from "./config";
+import { createBackendFromDriver } from "./factory";
+import { LazyBackend } from "./lazy-backend";
+
+// Mocks
+const mockBackend: Backend = vi.hoisted(() => ({
+  migrate: vi.fn().mockResolvedValue(undefined),
+  rollbackMigration: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+  createNewQueue: vi.fn().mockResolvedValue({ id: 1, name: "queue1" } as QueueConfig),
+  getQueue: vi.fn().mockResolvedValue({ id: 1, name: "queue1" } as QueueConfig),
+  getQueuesFromJobs: vi.fn().mockResolvedValue(["queue1", "queue2"]),
+  listQueues: vi.fn().mockResolvedValue([{ id: 1, name: "queue1" }] as QueueConfig[]),
+  updateQueue: vi.fn().mockResolvedValue({ id: 1, name: "queue1" } as QueueConfig),
+  getJob: vi.fn().mockResolvedValue({ id: 1 } as JobData),
+  createNewJob: vi.fn().mockResolvedValue({ id: 1 } as JobData),
+  claimPendingJob: vi.fn().mockResolvedValue([{ id: 1 }] as JobData[]),
+  updateJob: vi.fn().mockResolvedValue({ id: 1 } as JobData),
+  listJobs: vi.fn().mockResolvedValue([{ id: 1 }] as JobData[]),
+  countJobs: vi.fn().mockResolvedValue({ total: 1 } as JobCounts),
+  countJobsOverTime: vi.fn().mockResolvedValue([{ timestamp: new Date(), total: 1 }]),
+  staleJobs: vi.fn().mockResolvedValue([{ id: 1 }] as JobData[]),
+  deleteFinishedJobs: vi.fn().mockResolvedValue(undefined),
+  truncate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./factory", () => ({
+  createBackendFromDriver: vi.fn().mockResolvedValue(mockBackend),
+}));
+
+describe("LazyBackend", () => {
+  let config: BackendConfig;
+  let lazyBackend: LazyBackend;
+
+  beforeEach(() => {
+    config = { driver: "mock" } as BackendConfig;
+    lazyBackend = new LazyBackend(config);
+    vi.clearAllMocks();
+  });
+
+  it("should lazily initialize backend on first use", async () => {
+    // @ts-expect-error this exists
+    expect(lazyBackend.backend).toBeUndefined();
+    await lazyBackend.migrate();
+    expect(createBackendFromDriver).toHaveBeenCalledWith(config);
+    // @ts-expect-error this exists
+    expect(lazyBackend.backend).toBe(mockBackend);
+  });
+
+  it("should not re-initialize backend if already initialized", async () => {
+    await lazyBackend.migrate();
+    await lazyBackend.close();
+    expect(createBackendFromDriver).toHaveBeenCalledTimes(1);
+  });
+
+  it("should proxy migrate", async () => {
+    await lazyBackend.migrate();
+    expect(mockBackend.migrate).toHaveBeenCalled();
+  });
+
+  it("should proxy rollbackMigration", async () => {
+    await lazyBackend.rollbackMigration();
+    expect(mockBackend.rollbackMigration).toHaveBeenCalled();
+  });
+
+  it("should not call proxy close if not init", async () => {
+    await lazyBackend.close();
+    expect(mockBackend.close).not.toHaveBeenCalled();
+  });
+
+  it("should call proxy close if init", async () => {
+    await lazyBackend.migrate();
+    await lazyBackend.close();
+    expect(mockBackend.close).toHaveBeenCalled();
+  });
+
+  it("should proxy createNewQueue", async () => {
+    const queueConfig = { name: "test" } as NewQueueData;
+    const result = await lazyBackend.createNewQueue(queueConfig);
+    expect(mockBackend.createNewQueue).toHaveBeenCalledWith(queueConfig);
+    expect(result).toEqual({ id: 1, name: "queue1" });
+  });
+
+  it("should proxy getQueue", async () => {
+    const result = await lazyBackend.getQueue("queue1");
+    expect(mockBackend.getQueue).toHaveBeenCalledWith("queue1");
+    expect(result).toEqual({ id: 1, name: "queue1" });
+  });
+
+  it("should proxy getQueuesFromJobs", async () => {
+    const result = await lazyBackend.getQueuesFromJobs();
+    expect(mockBackend.getQueuesFromJobs).toHaveBeenCalled();
+    expect(result).toEqual(["queue1", "queue2"]);
+  });
+
+  it("should proxy listQueues", async () => {
+    const result = await lazyBackend.listQueues();
+    expect(mockBackend.listQueues).toHaveBeenCalled();
+    expect(result).toEqual([{ id: 1, name: "queue1" }]);
+  });
+
+  it("should proxy updateQueue", async () => {
+    const queueData = { id: 1, name: "queue1" } as UpdateQueueData;
+    const result = await lazyBackend.updateQueue(queueData);
+    expect(mockBackend.updateQueue).toHaveBeenCalledWith(queueData);
+    expect(result).toEqual({ id: 1, name: "queue1" });
+  });
+
+  it("should proxy getJob", async () => {
+    const result = await lazyBackend.getJob(1);
+    expect(mockBackend.getJob).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it("should proxy createNewJob", async () => {
+    const job = { queue: "queue1" } as NewJobData;
+    const result = await lazyBackend.createNewJob(job);
+    expect(mockBackend.createNewJob).toHaveBeenCalledWith(job);
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it("should proxy claimPendingJob", async () => {
+    const result = await lazyBackend.claimPendingJob("queue1", 2);
+    expect(mockBackend.claimPendingJob).toHaveBeenCalledWith("queue1", 2);
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it("should proxy updateJob", async () => {
+    const job = { id: 1 } as UpdateJobData;
+    const result = await lazyBackend.updateJob(job);
+    expect(mockBackend.updateJob).toHaveBeenCalledWith(job);
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it("should proxy listJobs", async () => {
+    const params = { queue: "queue1" };
+    const result = await lazyBackend.listJobs(params);
+    expect(mockBackend.listJobs).toHaveBeenCalledWith(params);
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it("should proxy countJobs", async () => {
+    const result = await lazyBackend.countJobs();
+    expect(mockBackend.countJobs).toHaveBeenCalled();
+    expect(result).toEqual({ total: 1 });
+  });
+
+  it("should proxy countJobsOverTime", async () => {
+    const result = await lazyBackend.countJobsOverTime("hour");
+    expect(mockBackend.countJobsOverTime).toHaveBeenCalledWith("hour");
+    expect(result[0]).toHaveProperty("timestamp");
+    expect(result[0]).toHaveProperty("total", 1);
+  });
+
+  it("should proxy staleJobs", async () => {
+    const result = await lazyBackend.staleJobs(1000, 2000);
+    expect(mockBackend.staleJobs).toHaveBeenCalledWith(1000, 2000);
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it("should proxy deleteFinishedJobs", async () => {
+    const date = new Date();
+    await lazyBackend.deleteFinishedJobs(date);
+    expect(mockBackend.deleteFinishedJobs).toHaveBeenCalledWith(date);
+  });
+
+  it("should proxy truncate", async () => {
+    await lazyBackend.truncate();
+    expect(mockBackend.truncate).toHaveBeenCalled();
+  });
+});

--- a/packages/backends/backend/src/lazy-backend.ts
+++ b/packages/backends/backend/src/lazy-backend.ts
@@ -1,0 +1,141 @@
+import { JobData, JobState, QueueConfig } from "packages/core/dist";
+import { Backend, JobCounts, NewJobData, NewQueueData, UpdateJobData, UpdateQueueData } from "./backend";
+import { BackendConfig } from "./config";
+import { createBackendFromDriver } from "./factory";
+
+/**
+ * A backend wrapper that lazily initializes the underlying backend implementation.
+ *
+ * `LazyBackend` defers the creation of the actual backend until it is needed,
+ * ensuring resources are only allocated when required. All backend operations
+ * are proxied to the underlying backend instance, which is created on first use.
+ *
+ * @remarks
+ * This class is useful for scenarios where backend initialization is expensive
+ * or should be deferred until an operation is actually performed.
+ *
+ * @example
+ * ```typescript
+ * const lazyBackend = new LazyBackend(config);
+ * await lazyBackend.createNewQueue(queueConfig);
+ * ```
+ *
+ * @param config - The configuration used to create the backend.
+ *
+ * @implements Backend
+ */
+export class LazyBackend implements Backend {
+  /**
+   * Optional instance of the {@link Backend} class.
+   * Used to store the backend implementation, which may be undefined if not yet initialized.
+   */
+  private backend?: Backend;
+
+  /**
+   * Creates an instance of the class with the provided backend configuration.
+   * @param config - The configuration object for the backend.
+   */
+  constructor(private config: BackendConfig) {}
+
+  async init(): Promise<void> {
+    this.backend ??= await createBackendFromDriver(this.config);
+  }
+
+  async migrate(): Promise<void> {
+    await this.init();
+    return this.backend!.migrate();
+  }
+
+  async rollbackMigration(): Promise<void> {
+    await this.init();
+    return this.backend!.rollbackMigration();
+  }
+
+  async close(): Promise<void> {
+    // Here we don't call init because if calling close before inniting, we want to avoid creating the backend.
+    return this.backend?.close();
+  }
+
+  async createNewQueue(queueConfig: NewQueueData): Promise<QueueConfig> {
+    await this.init();
+    return this.backend!.createNewQueue(queueConfig);
+  }
+
+  async getQueue(queue: string): Promise<QueueConfig | undefined> {
+    await this.init();
+    return this.backend!.getQueue(queue);
+  }
+
+  async getQueuesFromJobs(): Promise<string[]> {
+    await this.init();
+    return this.backend!.getQueuesFromJobs();
+  }
+
+  async listQueues(orderBy?: { column?: keyof QueueConfig; order?: "asc" | "desc" }): Promise<QueueConfig[]> {
+    await this.init();
+    return this.backend!.listQueues(orderBy);
+  }
+
+  async updateQueue(queueData: UpdateQueueData): Promise<QueueConfig> {
+    await this.init();
+    return this.backend!.updateQueue(queueData);
+  }
+
+  async getJob(id: number): Promise<JobData | undefined> {
+    await this.init();
+    return this.backend!.getJob(id);
+  }
+
+  async createNewJob(job: NewJobData): Promise<JobData> {
+    await this.init();
+    return this.backend!.createNewJob(job);
+  }
+
+  async claimPendingJob(queue: string, quantity?: number): Promise<JobData[]> {
+    await this.init();
+    return this.backend!.claimPendingJob(queue, quantity);
+  }
+
+  async updateJob(job: UpdateJobData): Promise<JobData> {
+    await this.init();
+    return this.backend!.updateJob(job);
+  }
+
+  async listJobs(params?: {
+    queue?: string | string[];
+    jobClass?: string | string[];
+    state?: JobState | JobState[];
+    limit?: number;
+    offset?: number;
+    args?: unknown[];
+    timeRange?: { from?: Date; to?: Date };
+  }): Promise<JobData[]> {
+    await this.init();
+    return this.backend!.listJobs(params);
+  }
+
+  async countJobs(timeRange?: { from?: Date; to?: Date }): Promise<JobCounts> {
+    await this.init();
+    return this.backend!.countJobs(timeRange);
+  }
+
+  async countJobsOverTime(timeRange: string): Promise<({ timestamp: Date } & JobCounts)[]> {
+    await this.init();
+    return this.backend!.countJobsOverTime(timeRange);
+  }
+
+  async staleJobs(maxStaleMs?: number, maxClaimedMs?: number): Promise<JobData[]> {
+    await this.init();
+    return this.backend!.staleJobs(maxStaleMs, maxClaimedMs);
+  }
+
+  async deleteFinishedJobs(cutoffDate: Date): Promise<void> {
+    await this.init();
+    return this.backend!.deleteFinishedJobs(cutoffDate);
+  }
+
+  async truncate(): Promise<void> {
+    await this.init();
+    return this.backend!.truncate();
+  }
+}

--- a/packages/backends/backend/src/lazy-backend.ts
+++ b/packages/backends/backend/src/lazy-backend.ts
@@ -1,4 +1,4 @@
-import { JobData, JobState, QueueConfig } from "packages/core/dist";
+import { JobData, JobState, QueueConfig } from "@sidequest/core";
 import { Backend, JobCounts, NewJobData, NewQueueData, UpdateJobData, UpdateQueueData } from "./backend";
 import { BackendConfig } from "./config";
 import { createBackendFromDriver } from "./factory";

--- a/packages/docs/jobs/recurring.md
+++ b/packages/docs/jobs/recurring.md
@@ -67,6 +67,6 @@ Sidequest.build(MyJob).schedule("*/5 * * * * *", "foo"); // Every 5 seconds with
 ## Limitations and Recommendations
 
 - **Persistence:** If your application restarts, any scheduled jobs must be re-scheduled via code. (This is by design and similar to other popular job libraries.)
-- **Clustering:** In a multi-instance environment, each instance will create its own scheduled jobs unless you coordinate or restrict scheduling to a single node. 
-  To avoid duplicate executions, we recommend enabling job uniqueness with a period window (e.g., “unique per hour” or “unique per minute”). 
+- **Clustering:** In a multi-instance environment, each instance will create its own scheduled jobs unless you coordinate or restrict scheduling to a single node.
+  To avoid duplicate executions, we recommend enabling job uniqueness with a period window (e.g., “unique per hour” or “unique per minute”).
   This ensures that even if multiple nodes schedule the same job, only one will actually run for each interval.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -25,6 +25,9 @@
     "node-cron": "^4.1.1",
     "piscina": "^5.1.2"
   },
+  "peerDependencies": {
+    "sidequest": "workspace:*"
+  },
   "packageManager": "yarn@4.9.2",
   "stableVersion": "1.0.0-next.3"
 }

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -111,58 +111,6 @@ describe("Engine", () => {
 
       await engine.close();
     });
-
-    sidequestTest("should configure queues during setup", async () => {
-      const engine = new Engine();
-      const queues = [
-        { name: "high-priority", concurrency: 10, priority: 10 },
-        { name: "low-priority", concurrency: 2, priority: 1 },
-      ];
-
-      await engine.configure({
-        backend: { driver: "@sidequest/sqlite-backend", config: ":memory:" },
-        queues,
-      });
-
-      const backend = engine.getBackend()!;
-
-      // Verify queues were created in the backend
-      const queueList = await backend.listQueues();
-      expect(queueList.map((q) => q.name)).toContain("high-priority");
-      expect(queueList.map((q) => q.name)).toContain("low-priority");
-
-      await engine.close();
-    });
-
-    sidequestTest("should enforce queues configs during setup", async () => {
-      const engine = new Engine();
-      const queues = [{ name: "high-priority", concurrency: 10, priority: 10 }];
-
-      await engine.configure({
-        backend: { driver: "@sidequest/sqlite-backend", config: ":memory:" },
-        queues,
-      });
-
-      let backend = engine.getBackend()!;
-      let queueList = await backend.listQueues();
-
-      await backend.updateQueue({ ...queueList[0], priority: 20 });
-      queueList = await backend.listQueues();
-      expect(queueList[0].name).toBe("high-priority");
-      expect(queueList[0].priority).toBe(20);
-
-      await engine.close();
-
-      await engine.configure({
-        backend: { driver: "@sidequest/sqlite-backend", config: ":memory:" },
-        queues,
-      });
-      backend = engine.getBackend()!;
-
-      queueList = await backend.listQueues();
-      expect(queueList[0].name).toBe("high-priority");
-      expect(queueList[0].priority).toBe(10);
-    });
   });
 
   describe("getConfig", () => {

--- a/packages/engine/src/execution/dispatcher.test.ts
+++ b/packages/engine/src/execution/dispatcher.test.ts
@@ -1,8 +1,7 @@
 import { sidequestTest, SidequestTestFixture } from "@/tests/fixture";
 import { Backend } from "@sidequest/backend";
 import { CompletedResult, JobData } from "@sidequest/core";
-import { NonNullableEngineConfig } from "packages/engine/dist";
-import { EngineConfig } from "../engine";
+import { EngineConfig, NonNullableEngineConfig } from "../engine";
 import { DummyJob } from "../test-jobs/dummy-job";
 import { Dispatcher } from "./dispatcher";
 import { ExecutorManager } from "./executor-manager";

--- a/packages/engine/src/execution/dispatcher.test.ts
+++ b/packages/engine/src/execution/dispatcher.test.ts
@@ -1,6 +1,7 @@
 import { sidequestTest, SidequestTestFixture } from "@/tests/fixture";
 import { Backend } from "@sidequest/backend";
 import { CompletedResult, JobData } from "@sidequest/core";
+import { NonNullableEngineConfig } from "packages/engine/dist";
 import { EngineConfig } from "../engine";
 import { DummyJob } from "../test-jobs/dummy-job";
 import { Dispatcher } from "./dispatcher";
@@ -58,7 +59,7 @@ describe("Dispatcher", () => {
       const dispatcher = new Dispatcher(
         backend,
         new QueueManager(backend, config.queues!),
-        new ExecutorManager(backend, config.maxConcurrentJobs!, 2, 4),
+        new ExecutorManager(backend, config as NonNullableEngineConfig),
       );
       dispatcher.start();
 
@@ -82,7 +83,7 @@ describe("Dispatcher", () => {
       const dispatcher = new Dispatcher(
         backend,
         new QueueManager(backend, config.queues!),
-        new ExecutorManager(backend, config.maxConcurrentJobs!, 2, 4),
+        new ExecutorManager(backend, config as NonNullableEngineConfig),
       );
       dispatcher.start();
 
@@ -112,7 +113,7 @@ describe("Dispatcher", () => {
       const dispatcher = new Dispatcher(
         backend,
         new QueueManager(backend, config.queues!),
-        new ExecutorManager(backend, config.maxConcurrentJobs, 2, 4),
+        new ExecutorManager(backend, config as NonNullableEngineConfig),
       );
       dispatcher.start();
 

--- a/packages/engine/src/execution/executor-manager.ts
+++ b/packages/engine/src/execution/executor-manager.ts
@@ -1,6 +1,7 @@
 import { Backend } from "@sidequest/backend";
 import { JobData, JobTransitionFactory, logger, QueueConfig, RunTransition, SnoozeTransition } from "@sidequest/core";
 import EventEmitter from "events";
+import { NonNullableEngineConfig } from "../engine";
 import { JobTransitioner } from "../job/job-transitioner";
 import { RunnerPool } from "../shared-runner";
 
@@ -15,19 +16,15 @@ export class ExecutorManager {
   /**
    * Creates a new ExecutorManager.
    * @param backend The backend instance.
-   * @param maxConcurrentJobs The maximum number of concurrent jobs across all queues.
-   * @param minThreads Minimum number of worker threads to use.
-   * @param maxThreads Maximum number of worker threads to use.
+   * @param nonNullConfig The non-nullable engine configuration.
    */
   constructor(
     private backend: Backend,
-    private maxConcurrentJobs: number,
-    private minThreads: number,
-    private maxThreads: number,
+    private nonNullConfig: NonNullableEngineConfig,
   ) {
     this.activeByQueue = {};
     this.activeJobs = new Set();
-    this.runnerPool = new RunnerPool(this.minThreads, this.maxThreads);
+    this.runnerPool = new RunnerPool(this.nonNullConfig);
   }
 
   /**
@@ -54,7 +51,7 @@ export class ExecutorManager {
    * @returns The number of available slots.
    */
   availableSlotsGlobal() {
-    const limit = this.maxConcurrentJobs;
+    const limit = this.nonNullConfig.maxConcurrentJobs;
     const availableSlots = limit - this.activeJobs.size;
     if (availableSlots < 0) {
       return 0;

--- a/packages/engine/src/shared-runner/runner-pool.test.ts
+++ b/packages/engine/src/shared-runner/runner-pool.test.ts
@@ -20,7 +20,7 @@ describe("RunnerPool", () => {
   let pool: RunnerPool;
   let jobData: JobData;
 
-  beforeEach<SidequestTestFixture>(async ({ backend }) => {
+  beforeEach<SidequestTestFixture>(async ({ backend, config }) => {
     const job = new DummyJob();
     await job.ready();
 
@@ -34,15 +34,15 @@ describe("RunnerPool", () => {
       state: "waiting",
     });
 
-    pool = new RunnerPool(2, 4);
+    pool = new RunnerPool(config);
   });
 
-  sidequestTest("should call pool.run with job data", async () => {
+  sidequestTest("should call pool.run with job data", async ({ config }) => {
     const emiter = new EventEmitter();
     const result = await pool.run(jobData, emiter);
 
     expect(result).toEqual({ type: "completed", result: "ok" });
-    expect(piscinaMockInstance.run).toHaveBeenCalledWith(jobData, { signal: emiter });
+    expect(piscinaMockInstance.run).toHaveBeenCalledWith({ jobData, config }, { signal: emiter });
   });
 
   sidequestTest("should call pool.destroy", async () => {

--- a/packages/engine/src/shared-runner/runner.test.ts
+++ b/packages/engine/src/shared-runner/runner.test.ts
@@ -2,7 +2,12 @@ import { sidequestTest, SidequestTestFixture } from "@/tests/fixture";
 import { FailedResult, JobData } from "@sidequest/core";
 import { vi } from "vitest";
 import { DummyJob } from "../test-jobs/dummy-job";
-import run from "./runner";
+import { importSidequest } from "../utils/import";
+import run, { injectSidequestConfig } from "./runner";
+
+vi.mock("../utils/import", () => ({
+  importSidequest: vi.fn(),
+}));
 
 describe("runner.ts", () => {
   let jobData: JobData;
@@ -22,30 +27,30 @@ describe("runner.ts", () => {
     });
   });
 
-  sidequestTest("runs a job", async () => {
-    const result = await run(jobData);
+  sidequestTest("runs a job", async ({ config }) => {
+    const result = await run({ jobData, config });
     expect(result).toEqual({ __is_job_transition__: true, type: "completed", result: "dummy job" });
   });
 
-  sidequestTest("fails with invalid script", async () => {
+  sidequestTest("fails with invalid script", async ({ config }) => {
     jobData.script = "invalid!";
-    const result = (await run(jobData)) as FailedResult;
+    const result = (await run({ jobData, config })) as FailedResult;
     expect(result.type).toEqual("failed");
     expect(result.error.message).toMatch(/Cannot find package 'invalid!'/);
   });
 
-  sidequestTest("fails with invalid class", async () => {
+  sidequestTest("fails with invalid class", async ({ config }) => {
     jobData.class = "InvalidClass";
-    const result = (await run(jobData)) as FailedResult;
+    const result = (await run({ jobData, config })) as FailedResult;
     expect(result.type).toEqual("failed");
     expect(result.error.message).toMatch(/Invalid job class: InvalidClass/);
   });
 
-  sidequestTest("calls injectJobData with the correct jobData", async () => {
+  sidequestTest("calls injectJobData with the correct jobData", async ({ config }) => {
     // Spy on the DummyJob prototype's injectJobData method
     const injectJobDataSpy = vi.spyOn(DummyJob.prototype, "injectJobData");
 
-    await run(jobData);
+    await run({ jobData, config });
 
     // Verify that injectJobData was called with the correct jobData
     expect(injectJobDataSpy).toHaveBeenCalledWith(jobData);
@@ -53,5 +58,33 @@ describe("runner.ts", () => {
 
     // Clean up the spy
     injectJobDataSpy.mockRestore();
+  });
+});
+
+describe("injectSidequestConfig", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  sidequestTest("injects config successfully", async ({ config }) => {
+    const configureMock = vi.fn().mockResolvedValue(undefined);
+    // Set up the mock for importSidequest
+    // @ts-expect-error this is correct
+    vi.mocked(importSidequest).mockResolvedValue({ Sidequest: { configure: configureMock } });
+
+    const result = await injectSidequestConfig(config);
+
+    expect(configureMock).toHaveBeenCalledWith({ ...config, skipMigration: true });
+    expect(result).toBe(true);
+  });
+
+  sidequestTest("returns false and logs warning on error", async ({ config }) => {
+    // Set up the mock for importSidequest to reject
+    vi.mocked(importSidequest).mockRejectedValue(new Error("Import failed"));
+
+    const result = await injectSidequestConfig(config);
+
+    expect(result).toBe(false);
   });
 });

--- a/packages/engine/src/shared-runner/runner.test.ts
+++ b/packages/engine/src/shared-runner/runner.test.ts
@@ -69,8 +69,9 @@ describe("injectSidequestConfig", () => {
 
   sidequestTest("injects config successfully", async ({ config }) => {
     const configureMock = vi.fn().mockResolvedValue(undefined);
-    // Set up the mock for importSidequest
-    // @ts-expect-error this is correct
+    // @ts-expect-error TypeScript does not recognize the mocked structure as valid,
+    // but this is correct because vi.mocked is used to mock the importSidequest function,
+    // and the runtime behavior has been verified to match the expected type.
     vi.mocked(importSidequest).mockResolvedValue({ Sidequest: { configure: configureMock } });
 
     const result = await injectSidequestConfig(config);

--- a/packages/engine/src/shared-runner/runner.ts
+++ b/packages/engine/src/shared-runner/runner.ts
@@ -53,8 +53,8 @@ export default async function run({ jobData, config }: { jobData: JobData; confi
 export async function injectSidequestConfig(config: EngineConfig) {
   try {
     logger("Runner").debug("Injecting Sidequest config into job script");
-    const sidequest = await importSidequest();
-    await sidequest.Sidequest.configure({ ...config, skipMigration: true });
+    const { Sidequest } = await importSidequest();
+    await Sidequest.configure({ ...config, skipMigration: true });
     logger("Runner").debug("Successfully injected Sidequest config");
     return true;
   } catch (error) {

--- a/packages/engine/src/shared-runner/runner.ts
+++ b/packages/engine/src/shared-runner/runner.ts
@@ -1,12 +1,17 @@
 import { JobData, JobResult, logger, toErrorData } from "@sidequest/core";
+import { EngineConfig } from "../engine";
 import { Job, JobClassType } from "../job/job";
+import { importSidequest } from "../utils";
 
 /**
  * Runs a job by dynamically importing its script and executing the specified class.
- * @param jobData The job data to execute.
+ * @param jobData The job data containing script and class information
+ * @param config The non-nullable engine configuration.
  * @returns A promise resolving to the job result.
  */
-export default async function run(jobData: JobData): Promise<JobResult> {
+export default async function run({ jobData, config }: { jobData: JobData; config: EngineConfig }): Promise<JobResult> {
+  await injectSidequestConfig(config);
+
   let script: Record<string, JobClassType> = {};
   try {
     logger("Runner").debug(`Importing job script "${jobData.script}"`);
@@ -26,8 +31,36 @@ export default async function run(jobData: JobData): Promise<JobResult> {
     const errorData = toErrorData(new Error(error));
     return { __is_job_transition__: true, type: "failed", error: errorData };
   }
+
   const job: Job = new JobClass(jobData.constructor_args);
   job.injectJobData(jobData);
+
   logger("Runner").debug(`Executing job class "${jobData.class}" with args:`, jobData.args);
   return job.perform(...jobData.args);
+}
+
+/**
+ * Injects the provided Sidequest engine configuration into the job script.
+ *
+ * Dynamically imports the `Sidequest` module and applies the configuration,
+ * ensuring migrations are skipped. Logs the process and handles errors gracefully,
+ * allowing execution to proceed even if configuration injection fails.
+ *
+ * @param config - The engine configuration object to inject into Sidequest.
+ * @returns A promise that resolves to `true` if the configuration was injected successfully,
+ *          or `false` if an error occurred.
+ */
+export async function injectSidequestConfig(config: EngineConfig) {
+  try {
+    logger("Runner").debug("Injecting Sidequest config into job script");
+    const sidequest = await importSidequest();
+    await sidequest.Sidequest.configure({ ...config, skipMigration: true });
+    logger("Runner").debug("Successfully injected Sidequest config");
+    return true;
+  } catch (error) {
+    logger("Runner").warn(
+      `Failed to inject Sidequest config: ${error instanceof Error ? error.message : String(error)}. Proceeding anyway.`,
+    );
+    return false;
+  }
 }

--- a/packages/engine/src/sidequest.d.ts
+++ b/packages/engine/src/sidequest.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="./engine" />
+declare module "sidequest" {
+  export const Sidequest: {
+    configure: (config: EngineConfig) => Promise<void>;
+  };
+}

--- a/packages/engine/src/utils/import.ts
+++ b/packages/engine/src/utils/import.ts
@@ -1,0 +1,8 @@
+/**
+ * Dynamically imports the "sidequest" module.
+ *
+ * @returns A promise that resolves to the imported "sidequest" module.
+ */
+export async function importSidequest() {
+  return await import("sidequest");
+}

--- a/packages/engine/src/utils/index.ts
+++ b/packages/engine/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from "./import";
 export * from "./shutdown";

--- a/packages/engine/src/workers/main.ts
+++ b/packages/engine/src/workers/main.ts
@@ -28,12 +28,7 @@ export class MainWorker {
         this.dispatcher = new Dispatcher(
           this.backend,
           new QueueManager(this.backend, nonNullConfig.queues, nonNullConfig.queueDefaults),
-          new ExecutorManager(
-            this.backend,
-            nonNullConfig.maxConcurrentJobs,
-            nonNullConfig.minThreads,
-            nonNullConfig.maxThreads,
-          ),
+          new ExecutorManager(this.backend, nonNullConfig),
         );
         this.dispatcher.start();
 

--- a/rollup.config.base.js
+++ b/rollup.config.base.js
@@ -5,7 +5,11 @@ import typescript from "@rollup/plugin-typescript";
 import dts from "rollup-plugin-dts";
 
 export default function createConfig(pkg, input = "src/index.ts", plugins = []) {
-  const external = [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})];
+  const external = [
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {}),
+    ...Object.keys(pkg.optionalDependencies || {}),
+  ];
 
   // Shared base plugins (without replace)
   const basePlugins = () => [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,6 +2652,8 @@ __metadata:
     "@sidequest/core": "workspace:*"
     node-cron: "npm:^4.1.1"
     piscina: "npm:^5.1.2"
+  peerDependencies:
+    sidequest: "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] All tests pass (`yarn test:all`)
- [X] Code follows the style guide and passes lint checks
- [X] Documentation is updated (README, docs, etc)
- [X] Linked to corresponding issue, if applicable

## Summary of Changes

* Creates the LazyBackend for lazy loading backend only on the first call (used by engine for lazy loading)
* Injects Sidequest config when running a job. This allows us to enqueue jobs from within other jobs. It also enables using other backend stuff.

Closes #14 
