### PR TITLE
feat(postgres): add pooling control for PG knex config

### DIFF
--- a/packages/backends/postgres/README.md
+++ b/packages/backends/postgres/README.md
@@ -79,6 +79,24 @@ backend: {
 }
 ```
 
+**PostgreSQL with more complex pooling config:**
+
+```typescript
+backend: {
+  driver: '@sidequest/postgres-backend',
+  config: {
+    connection: 'postgresql://user:password@localhost:5432'
+    pool: {
+      min: 5,
+      max: 50,
+      idleTimeoutMillis: 30000,
+      acquireTimeoutMillis: 10000,
+      createTimeoutMillis: 3000,
+    }
+  }
+}
+```
+
 ### Features
 
 - **Advanced Concurrency** - Uses PostgreSQL's robust locking mechanisms for safe job claiming

--- a/packages/backends/postgres/test/pooled.test.ts
+++ b/packages/backends/postgres/test/pooled.test.ts
@@ -1,0 +1,13 @@
+import { testBackend } from "@sidequest/backend-test";
+import PostgresBackend, { PostgresBackendConfig } from "../src/postgres-backend";
+
+const connection = process.env.POSTGRES_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres";
+const config: PostgresBackendConfig = {
+  connection,
+  pool: {
+    min: 5,
+    max: 20,
+  },
+};
+
+testBackend(() => new PostgresBackend(config));


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] All tests pass (`yarn test:all`)
- [x] Code follows the style guide and passes lint checks
- [x] Documentation is updated (README, docs, etc)
- [x] Linked to corresponding issue, if applicable

## Summary of Changes

In super high throughput scenarios, queuing thousands of jobs a sec cause pool availability issues given the default knex pooling config. It'd be very helpful to expose the pooling config for the underlying Knex pooling config. This PR attempts to do that. 

We could optionally expose some of the other config options, but those don't concern my needs at the moment. Happy to revise if it would help.
