### PR TITLE
fix: set schema name for migrations based on searchPath in PostgresBackend

### DIFF
--- a/packages/backends/postgres/src/postgres-backend.ts
+++ b/packages/backends/postgres/src/postgres-backend.ts
@@ -1,5 +1,4 @@
 import { SQLBackend, SQLDriverConfig } from "@sidequest/backend";
-import { logger } from "@sidequest/core";
 import createKnex, { Knex } from "knex";
 import path from "path";
 
@@ -72,29 +71,11 @@ export default class PostgresBackend extends SQLBackend {
   async migrate(): Promise<void> {
     // Create schema if it doesn't exist
     if (this.schemaName) {
-      await this.ensureSchemaExists(this.schemaName);
+      await this.knex.raw(`CREATE SCHEMA IF NOT EXISTS ??`, [this.schemaName]);
     }
 
     // Call parent migrate method
     await super.migrate();
-  }
-
-  /**
-   * Ensures that the specified PostgreSQL schema exists in the database.
-   * If the schema does not exist, it attempts to create it.
-   * Any errors encountered during creation (such as the schema already existing)
-   * are logged as warnings, but not thrown.
-   *
-   * @param schemaName - The name of the schema to ensure exists.
-   * @returns A promise that resolves when the operation is complete.
-   */
-  private async ensureSchemaExists(schemaName: string): Promise<void> {
-    try {
-      await this.knex.raw(`CREATE SCHEMA IF NOT EXISTS ??`, [schemaName]);
-    } catch (error) {
-      // Log the error but don't throw - the schema might already exist
-      logger("Backend").warn(`Could not create schema ${schemaName}:`, error);
-    }
   }
 
   truncDate(date: string, unit: "m" | "h" | "d"): string {

--- a/packages/backends/postgres/src/postgres-backend.ts
+++ b/packages/backends/postgres/src/postgres-backend.ts
@@ -45,6 +45,11 @@ export default class PostgresBackend extends SQLBackend {
       ...(typeof dbConfig === "string" ? { connection: dbConfig } : dbConfig),
     };
 
+    if (knexConfig.searchPath) {
+      knexConfig.migrations!.schemaName =
+        typeof knexConfig.searchPath === "string" ? knexConfig.searchPath : knexConfig.searchPath[0];
+    }
+
     const knex = createKnex(knexConfig);
     super(knex);
   }

--- a/packages/backends/postgres/src/postgres-backend.ts
+++ b/packages/backends/postgres/src/postgres-backend.ts
@@ -1,4 +1,5 @@
 import { SQLBackend, SQLDriverConfig } from "@sidequest/backend";
+import { logger } from "@sidequest/core";
 import createKnex, { Knex } from "knex";
 import path from "path";
 
@@ -39,19 +40,61 @@ const defaultKnexConfig = {
  * @param dbConfig - Database configuration - can be a connection string or limited Knex config
  */
 export default class PostgresBackend extends SQLBackend {
+  private schemaName?: string;
+
   constructor(dbConfig: string | SQLDriverConfig) {
     const knexConfig: Knex.Config = {
       ...defaultKnexConfig,
       ...(typeof dbConfig === "string" ? { connection: dbConfig } : dbConfig),
     };
 
+    let schemaName: string | undefined;
     if (knexConfig.searchPath) {
-      knexConfig.migrations!.schemaName =
-        typeof knexConfig.searchPath === "string" ? knexConfig.searchPath : knexConfig.searchPath[0];
+      schemaName = typeof knexConfig.searchPath === "string" ? knexConfig.searchPath : knexConfig.searchPath[0];
+      knexConfig.migrations!.schemaName = schemaName;
     }
 
     const knex = createKnex(knexConfig);
     super(knex);
+
+    this.schemaName = schemaName;
+  }
+
+  /**
+   * Migrates the database by ensuring the required schema exists and then invoking the parent migration logic.
+   *
+   * @remarks
+   * If a schema name is specified, this method will attempt to create the schema if it does not already exist.
+   * After ensuring the schema, it delegates further migration steps to the parent class.
+   *
+   * @returns A promise that resolves when the migration process is complete.
+   */
+  async migrate(): Promise<void> {
+    // Create schema if it doesn't exist
+    if (this.schemaName) {
+      await this.ensureSchemaExists(this.schemaName);
+    }
+
+    // Call parent migrate method
+    await super.migrate();
+  }
+
+  /**
+   * Ensures that the specified PostgreSQL schema exists in the database.
+   * If the schema does not exist, it attempts to create it.
+   * Any errors encountered during creation (such as the schema already existing)
+   * are logged as warnings, but not thrown.
+   *
+   * @param schemaName - The name of the schema to ensure exists.
+   * @returns A promise that resolves when the operation is complete.
+   */
+  private async ensureSchemaExists(schemaName: string): Promise<void> {
+    try {
+      await this.knex.raw(`CREATE SCHEMA IF NOT EXISTS ??`, [schemaName]);
+    } catch (error) {
+      // Log the error but don't throw - the schema might already exist
+      logger("Backend").warn(`Could not create schema ${schemaName}:`, error);
+    }
   }
 
   truncDate(date: string, unit: "m" | "h" | "d"): string {

--- a/packages/backends/postgres/test/with-schema.test.ts
+++ b/packages/backends/postgres/test/with-schema.test.ts
@@ -1,0 +1,6 @@
+import { testBackend } from "@sidequest/backend-test";
+import PostgresBackend from "../src/postgres-backend";
+
+const connection = process.env.POSTGRES_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres";
+
+testBackend(() => new PostgresBackend({ connection, searchPath: "sidequest" }));


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] All tests pass (`yarn test:all` and `yarn test:integration`)
- [X] Code follows the style guide and passes lint checks
- [X] Documentation is updated (README, docs, etc)
- [X] Linked to corresponding issue, if applicable

## Summary of Changes

Closes #62 

* Creates schema automatically if it does not exist
* New tests for schema