### PR TITLE
fix: fix flaky integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:examples": "cross-env NODE_ENV=production turbo run build --filter=examples",
     "test": "yarn vitest --exclude packages/backends --exclude tests/integration",
     "test:integration": "yarn vitest --test-timeout=10000 tests/integration",
-    "test:integration:ci": "yarn vitest run --test-timeout=10000 tests/integration",
+    "test:integration:ci": "yarn vitest run --test-timeout=10000 --silent=passed-only tests/integration",
     "test:ci": "turbo run test:ci --filter=!'@sidequest/*-backend'",
     "test:debug": "yarn vitest --test-timeout=0 --exclude packages/backends --exclude tests/integration",
     "test:coverage": "vitest run --coverage --exclude packages/backends --exclude tests/integration",

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -233,13 +233,19 @@ export class SidequestDashboard {
    * @returns {Promise<void>} Resolves when all resources have been closed and cleaned up.
    */
   async close() {
-    await this.backend?.close();
-    await new Promise<void>((resolve) => {
-      this.server?.close(() => {
-        logger("Dashboard").info("Sidequest Dashboard stopped");
-        resolve();
+    try {
+      await this.backend?.close();
+    } catch (error) {
+      logger("Dashboard").error("Failed to close backend", error);
+    }
+    if (this.server) {
+      await new Promise<void>((resolve) => {
+        this.server!.close(() => {
+          logger("Dashboard").info("Sidequest Dashboard stopped");
+          resolve();
+        });
       });
-    });
+    }
 
     this.backend = undefined;
     this.server = undefined;

--- a/packages/dashboard/src/resources/dashboard.ts
+++ b/packages/dashboard/src/resources/dashboard.ts
@@ -27,10 +27,15 @@ export function createDashboardRouter(backend: Backend) {
     const { range = "12m" } = req.query;
     const from = new Date(Date.now() - rangeToMs(range as string));
     const jobs = await backend.countJobs({ from });
+    const jobsNoTimeLimit = await backend.countJobs();
 
     res.render("pages/index", {
       title: "Sidequest Dashboard",
-      stats: jobs,
+      stats: {
+        ...jobs,
+        waiting: jobsNoTimeLimit.waiting,
+        running: jobsNoTimeLimit.running,
+      },
     });
   });
 

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -246,7 +246,11 @@ export class Engine {
         this.mainWorker.send({ type: "shutdown" });
         await promise;
       }
-      await this.backend?.close();
+      try {
+        await this.backend?.close();
+      } catch (error) {
+        logger("Engine").error("Error closing backend:", error);
+      }
       this.config = undefined;
       this.backend = undefined;
       this.mainWorker = undefined;

--- a/packages/engine/src/execution/executor-manager.ts
+++ b/packages/engine/src/execution/executor-manager.ts
@@ -155,12 +155,17 @@ export class ExecutorManager {
    * Destroys the runner pool and releases resources.
    */
   async destroy(): Promise<void> {
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       const checkJobs = async () => {
         if (this.totalActiveWorkers() === 0) {
           logger("ExecutorManager").info("All active jobs finished. Destroying runner pool.");
-          await this.runnerPool.destroy();
-          resolve();
+          try {
+            await this.runnerPool.destroy();
+            resolve();
+          } catch (error) {
+            logger("ExecutorManager").error("Error while destroying runner pool:", error);
+            reject(error as Error);
+          }
         } else {
           logger("ExecutorManager").info(`Waiting for ${this.totalActiveWorkers()} active jobs to finish...`);
           setTimeout(() => void checkJobs(), 1000);

--- a/packages/engine/src/execution/executor-manager.ts
+++ b/packages/engine/src/execution/executor-manager.ts
@@ -161,6 +161,7 @@ export class ExecutorManager {
           logger("ExecutorManager").info("All active jobs finished. Destroying runner pool.");
           try {
             await this.runnerPool.destroy();
+            logger("ExecutorManager").debug("Runner pool destroyed. Returning.");
             resolve();
           } catch (error) {
             logger("ExecutorManager").error("Error while destroying runner pool:", error);

--- a/packages/engine/src/execution/executor-manager.ts
+++ b/packages/engine/src/execution/executor-manager.ts
@@ -156,11 +156,11 @@ export class ExecutorManager {
    */
   async destroy(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      const checkJobs = async () => {
+      const checkJobs = () => {
         if (this.totalActiveWorkers() === 0) {
           logger("ExecutorManager").info("All active jobs finished. Destroying runner pool.");
           try {
-            await this.runnerPool.destroy();
+            this.runnerPool.destroy();
             logger("ExecutorManager").debug("Runner pool destroyed. Returning.");
             resolve();
           } catch (error) {
@@ -169,7 +169,7 @@ export class ExecutorManager {
           }
         } else {
           logger("ExecutorManager").info(`Waiting for ${this.totalActiveWorkers()} active jobs to finish...`);
-          setTimeout(() => void checkJobs(), 1000);
+          setTimeout(checkJobs, 1000);
         }
       };
 

--- a/packages/engine/src/shared-runner/runner-pool.test.ts
+++ b/packages/engine/src/shared-runner/runner-pool.test.ts
@@ -45,8 +45,8 @@ describe("RunnerPool", () => {
     expect(piscinaMockInstance.run).toHaveBeenCalledWith({ jobData, config }, { signal: emiter });
   });
 
-  sidequestTest("should call pool.destroy", async () => {
-    await pool.destroy();
+  sidequestTest("should call pool.destroy", () => {
+    pool.destroy();
     expect(piscinaMockInstance.destroy).toHaveBeenCalled();
   });
 });

--- a/packages/engine/src/shared-runner/runner-pool.ts
+++ b/packages/engine/src/shared-runner/runner-pool.ts
@@ -44,5 +44,6 @@ export class RunnerPool {
   async destroy(): Promise<void> {
     logger("RunnerPool").debug("Destroying worker pool");
     await this.pool.destroy();
+    logger("RunnerPool").debug("Worker pool destroyed");
   }
 }

--- a/packages/engine/src/shared-runner/runner-pool.ts
+++ b/packages/engine/src/shared-runner/runner-pool.ts
@@ -41,9 +41,9 @@ export class RunnerPool {
   /**
    * Destroys the worker pool and releases resources.
    */
-  async destroy(): Promise<void> {
+  destroy(): void {
     logger("RunnerPool").debug("Destroying worker pool");
-    await this.pool.destroy();
+    void this.pool.destroy();
     logger("RunnerPool").debug("Worker pool destroyed");
   }
 }

--- a/packages/engine/src/workers/main.test.ts
+++ b/packages/engine/src/workers/main.test.ts
@@ -8,7 +8,7 @@ import { cleanupFinishedJobs } from "../routines/cleanup-finished-job";
 import { releaseStaleJobs } from "../routines/release-stale-jobs";
 import { MainWorker } from "./main";
 
-const runMock = vi.fn();
+const runMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../shared-runner", () => ({
   RunnerPool: vi.fn(() => ({
@@ -51,6 +51,7 @@ describe("main.ts", () => {
   let worker: MainWorker;
 
   beforeEach<SidequestTestFixture>(async ({ backend, config }) => {
+    await backend.migrate();
     worker = new MainWorker();
     for (const queue of queues) {
       await grantQueueConfig(backend, queue);

--- a/packages/engine/src/workers/main.ts
+++ b/packages/engine/src/workers/main.ts
@@ -54,8 +54,11 @@ export class MainWorker {
   async shutdown() {
     if (!this.shuttingDown) {
       this.shuttingDown = true;
+      logger("Worker").debug("Shutting down dispatcher");
       await this.dispatcher?.stop();
+      logger("Worker").debug("Shutting down engine");
       await this.engine.close();
+      logger("Worker").debug("Main worker completely shut down");
     }
   }
 

--- a/packages/engine/src/workers/main.ts
+++ b/packages/engine/src/workers/main.ts
@@ -22,7 +22,7 @@ export class MainWorker {
   async runWorker(sidequestConfig: EngineConfig) {
     if (!this.shuttingDown) {
       try {
-        const nonNullConfig = await this.engine.configure(sidequestConfig);
+        const nonNullConfig = await this.engine.configure({ ...sidequestConfig, skipMigration: true });
         this.backend = this.engine.getBackend()!;
 
         this.dispatcher = new Dispatcher(

--- a/tests/fixture.ts
+++ b/tests/fixture.ts
@@ -1,3 +1,4 @@
+import { unlinkSync } from "fs";
 import { test as baseTest } from "vitest";
 import { Backend } from "../packages/backends/backend/src";
 import { Engine, NonNullableEngineConfig } from "../packages/engine/src";
@@ -13,7 +14,7 @@ export const sidequestTest = baseTest.extend<SidequestTestFixture>({
   engine: async ({}, use) => {
     const engine = new Engine();
     await engine.configure({
-      backend: { driver: "@sidequest/sqlite-backend", config: ":memory:" },
+      backend: { driver: "@sidequest/sqlite-backend", config: "./sidequest.sqlite" },
     });
 
     await use(engine);
@@ -31,6 +32,7 @@ export const sidequestTest = baseTest.extend<SidequestTestFixture>({
 
     try {
       await backend.truncate();
+      unlinkSync("./sidequest.sqlite");
     } catch {
       // noop
     }

--- a/tests/integration/shared-test-suite.js
+++ b/tests/integration/shared-test-suite.js
@@ -6,7 +6,7 @@ const backend = {
 };
 
 const logger = {
-  level: "info",
+  level: "debug",
 };
 
 export function createIntegrationTestSuite(Sidequest, jobs, moduleType = "ESM") {

--- a/tests/integration/shared-test-suite.js
+++ b/tests/integration/shared-test-suite.js
@@ -6,7 +6,7 @@ const backend = {
 };
 
 const logger = {
-  level: "debug",
+  level: "info",
 };
 
 export function createIntegrationTestSuite(Sidequest, jobs, moduleType = "ESM") {


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] All tests pass (`yarn test:all` and `yarn test:integration`)
- [X] Code follows the style guide and passes lint checks
- [X] Documentation is updated (README, docs, etc)
- [X] Linked to corresponding issue, if applicable

## Summary of Changes

Fixes a few flaky tests. The main culprit was the backend doing migrations (???) in parallel and breaking. This caused the dashboard or the engine to never close.
Well, it seems to have fixed the issue at least.

It also makes the dashboard show all the waiting and running, regardless of time limits.
