### PR TITLE
feat(engine): add config option to override start path for manual job resolution (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ import { EmailJob } from "./jobs/EmailJob.js";
 await Sidequest.build(EmailJob).enqueue("user@example.com", "Welcome!", "Thanks for signing up!");
 ```
 
+### 4. Manual Job Resolution (optional)
+
+By default, Sidequest automatically resolves job classes from their file paths.  
+If you prefer a central registry (e.g. `sidequest.jobs.js`) or need to load jobs from a custom build directory, enable **manual job resolution**:
+
+```ts
+await Sidequest.start({
+  backend: { driver: "@sidequest/postgres-backend" },
+  manualJobResolution: true,
+  paths: {
+    start: "./dist/sidequest.jobs.js", // optional override
+  },
+});
+```
+
+See the full guide: [Manual Job Resolution docs](https://github.com/sidequestjs/sidequest/blob/master/packages/docs/jobs/manual-resolution.md).
+
 ## 🤝 Contributing
 
 We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details.

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -71,6 +71,37 @@ export interface EngineConfig {
    * Defaults to `false`.
    */
   manualJobResolution?: boolean;
+
+  /**
+   * Optional configuration for custom file system paths.
+   */
+  paths?: {
+    /**
+     * Override path for the `sidequest.jobs.js` (or `.ts`) entry file used in
+     * manual job resolution mode.
+     *
+     * By default, Sidequest will search upward from `process.cwd()` to locate
+     * a `sidequest.jobs.js` file. If this property is set, Sidequest will use
+     * the provided path directly instead of searching.
+     *
+     * This is useful when:
+     * - The jobs file is transpiled into a build directory (e.g., `build/sidequest.jobs.js`)
+     * - You want Sidequest to load jobs from a non-standard location
+     * - Your project has multiple job registries
+     *
+     * @example
+     * ```ts
+     * await Sidequest.start({
+     *   backend: { driver: "@sidequest/sqlite-backend", config: "./sidequest.sqlite" },
+     *   manualJobResolution: true,
+     *   paths: {
+     *     start: "./build/sidequest.jobs.js",
+     *   },
+     * });
+     * ```
+     */
+    start?: string;
+  };
 }
 
 /**
@@ -158,6 +189,9 @@ export class Engine {
         state: config?.queueDefaults?.state ?? QUEUE_FALLBACK.state,
       },
       manualJobResolution: config?.manualJobResolution ?? false,
+      paths: config?.paths ?? {
+        start: "sidequest.jobs.js",
+      },
     };
 
     if (this.config.maxConcurrentJobs !== undefined && this.config.maxConcurrentJobs < 1) {

--- a/packages/engine/src/shared-runner/manual-loader.test.ts
+++ b/packages/engine/src/shared-runner/manual-loader.test.ts
@@ -253,4 +253,24 @@ describe("findSidequestJobsScriptInParentDirs", () => {
       expect(result).toBe(pathToFileURL(filePath).href);
     });
   });
+
+  describe("startPath override", () => {
+    it("should resolve file directly from startPath when provided", () => {
+      const fileName = "custom.jobs.js";
+      const filePath = join(tempDir, fileName);
+      writeFileSync(filePath, "export default {};");
+
+      const result = findSidequestJobsScriptInParentDirs("sidequest.jobs.js", tempDir, filePath);
+
+      expect(result).toBe(pathToFileURL(filePath).href);
+    });
+
+    it("should throw if startPath does not exist", () => {
+      const invalidPath = join(tempDir, "missing.jobs.js");
+
+      expect(() => {
+        findSidequestJobsScriptInParentDirs("sidequest.jobs.js", tempDir, invalidPath);
+      }).toThrow(`Start path override "${invalidPath}" not found`);
+    });
+  });
 });

--- a/packages/engine/src/shared-runner/manual-loader.ts
+++ b/packages/engine/src/shared-runner/manual-loader.ts
@@ -31,7 +31,7 @@ export const MANUAL_SCRIPT_TAG = "sidequest.jobs.js";
 export function findSidequestJobsScriptInParentDirs(
   fileName = "sidequest.jobs.js",
   startDir = process.cwd(),
-  startPath?,
+  startPath?: string,
 ): string {
   if (startPath) {
     const resolved = resolve(process.cwd(), startPath);

--- a/packages/engine/src/shared-runner/manual-loader.ts
+++ b/packages/engine/src/shared-runner/manual-loader.ts
@@ -28,7 +28,18 @@ export const MANUAL_SCRIPT_TAG = "sidequest.jobs.js";
  * const packageFile = findFileInParentDirs("package.json", "/some/project/dir");
  * ```
  */
-export function findSidequestJobsScriptInParentDirs(fileName = "sidequest.jobs.js", startDir = process.cwd()): string {
+export function findSidequestJobsScriptInParentDirs(
+  fileName = "sidequest.jobs.js",
+  startDir = process.cwd(),
+  startPath?,
+): string {
+  if (startPath) {
+    const resolved = resolve(process.cwd(), startPath);
+    if (existsSync(resolved)) {
+      return pathToFileURL(resolved).href;
+    }
+    throw new Error(`Start path override "${startPath}" not found`);
+  }
   if (!fileName.trim()) {
     throw new Error("fileName must be a non-empty string");
   }

--- a/packages/engine/src/shared-runner/runner.ts
+++ b/packages/engine/src/shared-runner/runner.ts
@@ -21,7 +21,7 @@ export default async function run({ jobData, config }: { jobData: JobData; confi
       logger("Runner").debug("Manual job resolution is enabled; importing 'sidequest.jobs.js' job script.");
       try {
         // When manual job resolution is enabled, import from the sidequest.jobs.js script
-        scriptUrl = findSidequestJobsScriptInParentDirs();
+        scriptUrl = findSidequestJobsScriptInParentDirs("sidequest.jobs.js", process.cwd(), config?.paths?.start);
       } catch (error) {
         const errorMessage = `Failed to locate 'sidequest.jobs.js' for manual job resolution: ${error instanceof Error ? error.message : String(error)}`;
         logger("Runner").error(errorMessage);


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] All tests pass (`yarn test:all` and `yarn test:integration`)
- [X] Code follows the style guide and passes lint checks
- [X] Documentation is updated (README, docs, etc)
- [X] Linked to corresponding issue, if applicable

## Summary of Changes

This PR adds support for overriding the start path when using manual job resolution in Sidequest:
- Introduced a new config option `paths.start` in EngineConfig.
- Updated `findSidequestJobsScriptInParentDirs` to resolve from explicit override before falling back to existing upward directory search.
- Added unit tests for start path override.
- Updated Manual Job Resolution docs to explain how to use `paths.start` with build outputs.

This enables projects that transpile or emit `sidequest.jobs.js` to custom build directories to cleanly configure job resolution without patching the engine.

Closes #108