### PR TITLE
fix: mongo-backend multi-host URI support

### DIFF
--- a/packages/backends/mongo/src/mongo-backend.ts
+++ b/packages/backends/mongo/src/mongo-backend.ts
@@ -49,10 +49,8 @@ export default class MongoBackend implements Backend {
   private _connected: boolean;
 
   constructor(mongoUrl: string) {
-    const url = new URL(mongoUrl);
-    const dbName = url.pathname && url.pathname !== "/" ? url.pathname.replace(/^\//, "") : "test";
     this.client = new MongoClient(mongoUrl, { ignoreUndefined: true });
-    this.db = this.client.db(dbName);
+    this.db = this.client.db();
     this.jobs = this.db.collection<JobData>("sidequest_jobs");
     this.queues = this.db.collection<QueueConfig>("sidequest_queues");
     this.counters = this.db.collection("sidequest_counters");


### PR DESCRIPTION
## Checklist for Pull Requests

- [x] All tests pass (`yarn test:all` and `yarn test:integration`)
- [x] Code follows the style guide and passes lint checks
- [x] Documentation is updated (README, docs, etc)
- [x] Linked to corresponding issue, if applicable

## Summary of Changes

- Removed unnecessary parsing of mongo connection URI which broke for multi-node replicaset connections. 
- this.db now implicitly set from the connection URI defined database or default to "test" (mongo driver default behavior)

Closes #146 
