### PR TITLE
fix: correct state transition requirements

### DIFF
--- a/packages/core/src/transitions/snooze-transition.ts
+++ b/packages/core/src/transitions/snooze-transition.ts
@@ -10,7 +10,7 @@ import { JobTransition } from "./transition";
  * If the job is currently running, it will decrement the attempt count.
  * This allows the job to be retried after the delay.
  *
- * Only jobs in "waiting" or "running" state can be snoozed.
+ * Only jobs in "claimed" or "running" state can be snoozed.
  */
 export class SnoozeTransition extends JobTransition {
   /** The delay in milliseconds. */
@@ -40,6 +40,6 @@ export class SnoozeTransition extends JobTransition {
   }
 
   shouldRun(job: JobData): boolean {
-    return ["waiting", "running"].includes(job.state);
+    return ["claimed", "running"].includes(job.state);
   }
 }

--- a/packages/core/src/transitions/snooze-transition.ts
+++ b/packages/core/src/transitions/snooze-transition.ts
@@ -10,7 +10,7 @@ import { JobTransition } from "./transition";
  * If the job is currently running, it will decrement the attempt count.
  * This allows the job to be retried after the delay.
  *
- * Only jobs in "claimed" or "running" state can be snoozed.
+ * Only jobs in "waiting" or "claimed" or "running" state can be snoozed.
  */
 export class SnoozeTransition extends JobTransition {
   /** The delay in milliseconds. */
@@ -40,6 +40,6 @@ export class SnoozeTransition extends JobTransition {
   }
 
   shouldRun(job: JobData): boolean {
-    return ["claimed", "running"].includes(job.state);
+    return ["waiting", "claimed", "running"].includes(job.state);
   }
 }


### PR DESCRIPTION
## Checklist for Pull Requests

- [ ] All tests pass (`yarn test:all` and `yarn test:integration`)
- [ ] Code follows the style guide and passes lint checks
- [ ] Documentation is updated (README, docs, etc)
- [ ] Linked to corresponding issue, if applicable

```
//  yarn test:all

 Test Files  41 passed (41)
      Tests  1002 passed | 1 skipped (1003)
   Start at  20:16:07
   Duration  144.54s (transform 2.09s, setup 670ms, collect 8.39s, tests 119.99s, environment 14ms, prepare 5.70s)
```

## Summary of Changes

https://github.com/sidequestjs/sidequest/issues/150

Updated the SnoozeTransition transition to correctly transition jobs which are claimed but are not executable because of queue restrictions, back to waiting to retry execution.

