### PR TITLE
fix: fixes stale job handling with JobTransitioner

### DIFF
--- a/sidequest.jobs.js
+++ b/sidequest.jobs.js
@@ -1,9 +1,0 @@
-import {
-  EnqueueFromWithinJob,
-  FailingJob,
-  RetryJob,
-  SuccessJob,
-  TimeoutJob,
-} from "./tests/integration/jobs/test-jobs.js";
-
-export { EnqueueFromWithinJob, FailingJob, RetryJob, SuccessJob, TimeoutJob };

--- a/tests/integration/sidequest.jobs.js
+++ b/tests/integration/sidequest.jobs.js
@@ -1,3 +1,0 @@
-import { EnqueueFromWithinJob, FailingJob, RetryJob, SuccessJob, TimeoutJob } from "./jobs/test-jobs.js";
-
-export { EnqueueFromWithinJob, FailingJob, RetryJob, SuccessJob, TimeoutJob };


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] All tests pass (`yarn test:all` and `yarn test:integration`)
- [X] Code follows the style guide and passes lint checks
- [X] Documentation is updated (README, docs, etc)
- [X] Linked to corresponding issue, if applicable

## Summary of Changes

This PR fixes a bug where the stale job cleanup would not honor the `max_attempts` of a job. It would then cause Sidequest to keep re-executing stale jobs forever.

Closes #155 