### PR TITLE
fix: Fixes an issue with HTMX cache and forces sidequest-dark theme

### DIFF
--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -144,6 +144,15 @@ export class SidequestDashboard {
       res.locals.basePath = this.config!.basePath ?? "";
       next();
     });
+
+    // Fixes a HTMX bug where restoring the dashboard tab from cache causes it to show an unstyled page
+    // https://github.com/bigskysoftware/htmx/issues/497
+    this.app?.use((req, res, next) => {
+      if (req.headers["hx-request"]) {
+        res.setHeader("Cache-Control", "no-store, max-age=0");
+      }
+      next();
+    });
   }
 
   /**

--- a/packages/dashboard/src/views/layout.ejs
+++ b/packages/dashboard/src/views/layout.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full" data-theme="sidequest-dark">
   <head>
     <meta charset="UTF-8" />
     <title><%= title || 'Sidequest Dashboard' %></title>


### PR DESCRIPTION
## Checklist for Pull Requests

- [X] All tests pass (`yarn test:all` and `yarn test:integration`)
- [X] Code follows the style guide and passes lint checks
- [X] Documentation is updated (README, docs, etc)
- [X] Linked to corresponding issue, if applicable

## Summary of Changes

Fixes two issues. One with HTMX not loading styles when restoring the dashboard tab, and another that ha broken light theme (we force dark now).

Closes #166
Closes #165