### PR TITLE
chore: pin Yarn via corepack in release and deploy workflows

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
-      - name: Setup Latest Yarn
-        uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: berry
-          cache: false
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
 
       - name: Build project
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,11 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Setup Latest Yarn
-        uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: berry
-          cache: false
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
## Problem

The release of the previously merged change failed at the **Setup Latest Yarn** step with YN0028 (`The lockfile would have been modified by this install, which is explicitly forbidden`).

The `release` and `deploy-website` workflows used `threeal/setup-yarn-action@v2.0.0` with `version: berry`, which downloads the latest Yarn (4.17.0) and ignores the `packageManager: yarn@4.14.1` pin in `package.json`. The newer Yarn migrates the lockfile `__metadata.version` from 9 to 10, so the immutable install fails.

This is the same root cause already fixed for the build/test setup action; these two workflows don't use that composite action and were still floating to the latest Yarn.

## Fix

Replace the floating `threeal/setup-yarn-action` step with `corepack enable`, which provisions the pinned `yarn@4.14.1`, plus an explicit `yarn install --immutable`. `deploy-website` now installs deps explicitly since the removed action handled that.

## Pipeline audit

All workflows checked: `pull-request.yml` already uses the fixed composite action; `validate-branch.yml` runs no Yarn. No floating Yarn references remain anywhere under `.github`.

## Notes

- Verified locally that `yarn install --immutable` with the pinned 4.14.1 leaves `yarn.lock` untouched.
- The semantic-release publish itself can only run in CI with the release secrets; the part that was breaking (the install) is fixed.