### PR TITLE
feat: add inline execution mode (runner: "inline")

### DIFF
--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -40,6 +40,19 @@ export interface EngineConfig {
   cleanupFinishedJobsOlderThan?: number;
   /** Whether to enable graceful shutdown handling. Defaults to `true` */
   gracefulShutdown?: boolean;
+  /**
+   * How jobs are executed.
+   *
+   * - `"thread"` (default): jobs run in a pool of worker threads (piscina). Gives CPU isolation
+   *   and lets timeouts/cancellation forcibly abort a running job.
+   * - `"inline"`: jobs run in the current process/thread, with no worker pool. Timeouts and
+   *   cancellation become best-effort (a running job cannot be forcibly aborted) and a CPU-bound
+   *   job will block the event loop. Useful for single-process setups (serverless, tests, SQLite)
+   *   and required when jobs need access to live in-process state.
+   *
+   * Defaults to `"thread"`.
+   */
+  runner?: "thread" | "inline";
   /** Minimum number of worker threads to use. Defaults to number of CPUs */
   minThreads?: number;
   /** Maximum number of worker threads to use. Defaults to `minThreads * 2` */
@@ -155,6 +168,7 @@ export class Engine {
         json: config?.logger?.json ?? false,
       },
       gracefulShutdown: config?.gracefulShutdown ?? true,
+      runner: config?.runner ?? "thread",
       minThreads: config?.minThreads ?? cpus().length,
       maxThreads: config?.maxThreads ?? cpus().length * 2,
       idleWorkerTimeout: config?.idleWorkerTimeout ?? 10_000,

--- a/packages/engine/src/execution/executor-manager.test.ts
+++ b/packages/engine/src/execution/executor-manager.test.ts
@@ -8,11 +8,18 @@ import { DummyJob } from "../test-jobs/dummy-job";
 import { ExecutorManager } from "./executor-manager";
 
 const runMock = vi.hoisted(() => vi.fn());
+const inlineRunMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../shared-runner", () => ({
   RunnerPool: vi.fn().mockImplementation(function () {
     return {
       run: runMock,
+      destroy: vi.fn(),
+    };
+  }),
+  InlineRunner: vi.fn().mockImplementation(function () {
+    return {
+      run: inlineRunMock,
       destroy: vi.fn(),
     };
   }),
@@ -69,6 +76,23 @@ describe("ExecutorManager", () => {
       expect(executorManager.availableSlotsByQueue(queryConfig)).toEqual(1);
       expect(executorManager.availableSlotsGlobal()).toEqual(10);
       await executorManager.destroy();
+    });
+
+    sidequestTest("uses the inline runner when runner is 'inline'", async ({ backend, config }) => {
+      inlineRunMock.mockResolvedValue({
+        __is_job_transition__: true,
+        type: "completed",
+        result: "result",
+      } satisfies CompletedResult);
+      const queryConfig = await grantQueueConfig(backend, { name: "default", concurrency: 1 });
+      const executorManager = new ExecutorManager(backend, { ...config, runner: "inline" });
+
+      await executorManager.execute(queryConfig, jobData);
+
+      expect(inlineRunMock).toBeCalledWith(jobData, expect.any(EventEmitter));
+      expect(runMock).not.toHaveBeenCalled();
+      await executorManager.destroy();
+      inlineRunMock.mockReset();
     });
 
     sidequestTest("should abort job execution on job cancel", async ({ backend, config }) => {

--- a/packages/engine/src/execution/executor-manager.ts
+++ b/packages/engine/src/execution/executor-manager.ts
@@ -4,7 +4,7 @@ import EventEmitter from "events";
 import { inspect } from "util";
 import { NonNullableEngineConfig } from "../engine";
 import { JobTransitioner } from "../job/job-transitioner";
-import { RunnerPool } from "../shared-runner";
+import { InlineRunner, JobRunner, RunnerPool } from "../shared-runner";
 
 /**
  * Manages job execution and worker concurrency for Sidequest.
@@ -12,7 +12,7 @@ import { RunnerPool } from "../shared-runner";
 export class ExecutorManager {
   private activeByQueue: Record<string, Set<number>>;
   private activeJobs: Set<number>;
-  private runnerPool: RunnerPool;
+  private jobRunner: JobRunner;
 
   /**
    * Creates a new ExecutorManager.
@@ -25,7 +25,10 @@ export class ExecutorManager {
   ) {
     this.activeByQueue = {};
     this.activeJobs = new Set();
-    this.runnerPool = new RunnerPool(this.nonNullConfig);
+    this.jobRunner =
+      this.nonNullConfig.runner === "inline"
+        ? new InlineRunner(this.nonNullConfig)
+        : new RunnerPool(this.nonNullConfig);
   }
 
   /**
@@ -114,7 +117,7 @@ export class ExecutorManager {
 
       logger("Executor Manager").debug(`Running job ${job.id} in queue ${queueConfig.name}`);
 
-      const runPromise = this.runnerPool.run(job, signal);
+      const runPromise = this.jobRunner.run(job, signal);
 
       if (job.timeout) {
         void new Promise(() => {
@@ -155,13 +158,13 @@ export class ExecutorManager {
     await new Promise<void>((resolve, reject) => {
       const checkJobs = () => {
         if (this.totalActiveWorkers() === 0) {
-          logger("ExecutorManager").info("All active jobs finished. Destroying runner pool.");
+          logger("ExecutorManager").info("All active jobs finished. Destroying runner.");
           try {
-            this.runnerPool.destroy();
-            logger("ExecutorManager").debug("Runner pool destroyed. Returning.");
+            this.jobRunner.destroy();
+            logger("ExecutorManager").debug("Runner destroyed. Returning.");
             resolve();
           } catch (error) {
-            logger("ExecutorManager").error("Error while destroying runner pool:", error);
+            logger("ExecutorManager").error("Error while destroying runner:", error);
             reject(error as Error);
           }
         } else {

--- a/packages/engine/src/shared-runner/index.ts
+++ b/packages/engine/src/shared-runner/index.ts
@@ -1,4 +1,6 @@
 import * as runner from "./runner";
+export * from "./inline-runner";
+export * from "./job-runner";
 export * from "./manual-loader";
 export * from "./runner-pool";
 export { runner as run };

--- a/packages/engine/src/shared-runner/inline-runner.test.ts
+++ b/packages/engine/src/shared-runner/inline-runner.test.ts
@@ -1,0 +1,51 @@
+import { sidequestTest, SidequestTestFixture } from "@/tests/fixture";
+import { JobData } from "@sidequest/core";
+import { beforeEach, describe, expect, vi } from "vitest";
+import { DummyJob } from "../test-jobs/dummy-job";
+import { InlineRunner } from "./inline-runner";
+
+// Spy on the runner module's default export so we can assert how the InlineRunner delegates to it.
+vi.mock("./runner", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./runner")>();
+  return { default: vi.fn(original.default), injectSidequestConfig: original.injectSidequestConfig };
+});
+
+import run from "./runner";
+
+describe("InlineRunner", () => {
+  let runner: InlineRunner;
+  let jobData: JobData;
+
+  beforeEach<SidequestTestFixture>(async ({ backend, config }) => {
+    vi.clearAllMocks();
+
+    const job = new DummyJob();
+    await job.ready();
+
+    jobData = await backend.createNewJob({
+      class: job.className,
+      script: job.script,
+      args: [],
+      attempt: 0,
+      queue: "default",
+      constructor_args: [],
+      state: "waiting",
+    });
+
+    runner = new InlineRunner(config);
+  });
+
+  sidequestTest("runs the job in-process and returns its result", async () => {
+    const result = await runner.run(jobData);
+    expect(result).toEqual({ __is_job_transition__: true, type: "completed", result: "dummy job" });
+  });
+
+  sidequestTest("delegates to the runner with inline enabled (skips config injection)", async ({ config }) => {
+    await runner.run(jobData);
+    expect(run).toHaveBeenCalledWith({ jobData, config, inline: true });
+  });
+
+  sidequestTest("destroy is a no-op and does not throw", () => {
+    expect(() => runner.destroy()).not.toThrow();
+  });
+});

--- a/packages/engine/src/shared-runner/inline-runner.ts
+++ b/packages/engine/src/shared-runner/inline-runner.ts
@@ -1,0 +1,38 @@
+import { JobData, JobResult, logger } from "@sidequest/core";
+import { NonNullableEngineConfig } from "../engine";
+import { JobRunner } from "./job-runner";
+import run from "./runner";
+
+/**
+ * Runs jobs in the current process/thread instead of a worker thread pool.
+ *
+ * Used by the inline execution mode (`runner: "inline"`). Unlike {@link RunnerPool}, a running job
+ * cannot be forcibly aborted: cancellation and timeouts are best-effort only, and a CPU-bound job
+ * will block the event loop. In exchange, jobs run in the host process and can reach live
+ * in-process state (the basis for framework integrations like NestJS).
+ */
+export class InlineRunner implements JobRunner {
+  /**
+   * Creates a new InlineRunner.
+   * @param nonNullConfig The non-nullable engine configuration.
+   */
+  constructor(private nonNullConfig: NonNullableEngineConfig) {}
+
+  /**
+   * Runs a job in the current process. The abort signal is intentionally not accepted: inline
+   * execution has no separate thread to terminate.
+   * @param job The job data to run.
+   * @returns A promise resolving to the job result.
+   */
+  run(job: JobData): Promise<JobResult> {
+    logger("InlineRunner").debug(`Running job ${job.id} inline`);
+    return run({ jobData: job, config: this.nonNullConfig, inline: true });
+  }
+
+  /**
+   * Releases resources. No-op for the inline runner.
+   */
+  destroy(): void {
+    // There is no pool to tear down. In-flight jobs are awaited by the ExecutorManager.
+  }
+}

--- a/packages/engine/src/shared-runner/job-runner.ts
+++ b/packages/engine/src/shared-runner/job-runner.ts
@@ -1,0 +1,24 @@
+import { JobData, JobResult } from "@sidequest/core";
+import EventEmitter from "events";
+
+/**
+ * Abstraction over how a claimed job is actually executed.
+ *
+ * Implemented by the thread-based {@link RunnerPool} (piscina worker pool) and the
+ * {@link InlineRunner} (same-process execution). The {@link ExecutorManager} picks one based on
+ * the engine's `runner` configuration.
+ */
+export interface JobRunner {
+  /**
+   * Runs a job and resolves with its result.
+   * @param job The job data to run.
+   * @param signal Optional event emitter used to request cancellation/abort. May be ignored by
+   * implementations that cannot forcibly abort a running job (e.g. the inline runner).
+   */
+  run(job: JobData, signal?: EventEmitter): Promise<JobResult>;
+
+  /**
+   * Releases any resources held by the runner.
+   */
+  destroy(): void;
+}

--- a/packages/engine/src/shared-runner/runner-pool.ts
+++ b/packages/engine/src/shared-runner/runner-pool.ts
@@ -3,11 +3,12 @@ import EventEmitter from "events";
 import Piscina from "piscina";
 import { DEFAULT_RUNNER_PATH } from "../constants";
 import { NonNullableEngineConfig } from "../engine";
+import { JobRunner } from "./job-runner";
 
 /**
  * A pool of worker threads for running jobs in parallel using Piscina.
  */
-export class RunnerPool {
+export class RunnerPool implements JobRunner {
   /** The underlying Piscina worker pool. */
   private readonly pool: Piscina;
 

--- a/packages/engine/src/shared-runner/runner.test.ts
+++ b/packages/engine/src/shared-runner/runner.test.ts
@@ -52,6 +52,19 @@ describe("runner.ts", () => {
     expect(result).toEqual({ __is_job_transition__: true, type: "completed", result: "dummy job" });
   });
 
+  sidequestTest("injects the config when not inline", async ({ config }) => {
+    vi.mocked(importSidequest).mockClear();
+    await run({ jobData, config });
+    expect(importSidequest).toHaveBeenCalled();
+  });
+
+  sidequestTest("skips config injection when inline", async ({ config }) => {
+    vi.mocked(importSidequest).mockClear();
+    const result = await run({ jobData, config, inline: true });
+    expect(result).toEqual({ __is_job_transition__: true, type: "completed", result: "dummy job" });
+    expect(importSidequest).not.toHaveBeenCalled();
+  });
+
   sidequestTest("fails with invalid script", async ({ config }) => {
     jobData.script = "invalid!";
     const result = (await run({ jobData, config })) as FailedResult;

--- a/packages/engine/src/shared-runner/runner.ts
+++ b/packages/engine/src/shared-runner/runner.ts
@@ -11,8 +11,20 @@ import { findSidequestJobsScriptInParentDirs, MANUAL_SCRIPT_TAG, resolveScriptPa
  * @param config The non-nullable engine configuration.
  * @returns A promise resolving to the job result.
  */
-export default async function run({ jobData, config }: { jobData: JobData; config: EngineConfig }): Promise<JobResult> {
-  await injectSidequestConfig(config);
+export default async function run({
+  jobData,
+  config,
+  inline,
+}: {
+  jobData: JobData;
+  config: EngineConfig;
+  inline?: boolean;
+}): Promise<JobResult> {
+  // In inline mode the job runs in the host process, where Sidequest is already configured, so
+  // re-injecting the config is redundant. In a worker thread the module is fresh and needs it.
+  if (!inline) {
+    await injectSidequestConfig(config);
+  }
 
   let script: Record<string, JobClassType> = {};
   try {


### PR DESCRIPTION
Part of the `@sidequest/nestjs` work (PR 2a). Targets `feat/nestjs-integration`.

## What

Adds a `runner` engine config option:
- `"thread"` (default): the existing piscina worker-thread pool. No behavior change.
- `"inline"`: jobs run in the current process/thread, with no pool.

## How

- New `JobRunner` interface (`run(job, signal?)` + `destroy()`), implemented by both the existing `RunnerPool` and a new `InlineRunner`.
- `ExecutorManager` selects the implementation from `config.runner`.
- `InlineRunner` calls the existing `runner.ts` `run()` function directly (no piscina). `run()` gains an `inline` flag to skip the redundant `Sidequest.configure` injection, which is only needed in a fresh worker-thread module, not in the host process.

## Tradeoffs (documented on the config option)

Inline mode gives up CPU isolation and forcible abort: a running job cannot be killed, so timeouts and cancellation are best-effort, and a CPU-bound job blocks the event loop. In exchange, jobs run in the host process and can reach live in-process state. This is the groundwork for the no-fork mode (PR 2b) and the NestJS DI integration; it's also independently useful for serverless, tests without IPC, and SQLite single-writer.

## Tests

- `inline-runner.test.ts`: runs a job in-process, delegates with `inline: true`, no-op destroy.
- `runner.test.ts`: `inline: true` skips config injection; default still injects.
- `executor-manager.test.ts`: selects the inline runner when `runner: "inline"`.
- Full engine suite green (253 passing), lint + build + format clean.