### PR TITLE
feat: add no-fork execution mode (fork: false)

### DIFF
--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -24,6 +24,23 @@ vi.mock("child_process", () => ({
   }),
 }));
 
+// Mock the in-process worker runtime so the no-fork path doesn't run a real dispatcher loop.
+const workerRuntimeMocks = vi.hoisted(() => ({
+  start: vi.fn().mockResolvedValue(undefined),
+  shutdown: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./workers/worker-runtime", () => ({
+  WorkerRuntime: vi.fn(function () {
+    return {
+      start: workerRuntimeMocks.start,
+      shutdown: workerRuntimeMocks.shutdown,
+    };
+  }),
+}));
+
+import { fork } from "child_process";
+
 export class ParameterizedJob extends DummyJob {
   constructor(
     public param1: string,
@@ -397,6 +414,26 @@ describe("Engine", () => {
       expect(config!.gracefulShutdown).toBe(false);
 
       await engine.close();
+    });
+
+    sidequestTest("runs in-process and skips fork when fork is false", async () => {
+      vi.mocked(fork).mockClear();
+      workerRuntimeMocks.start.mockClear();
+      workerRuntimeMocks.shutdown.mockClear();
+
+      const engine = new Engine();
+
+      await engine.start({
+        backend: { driver: "@sidequest/sqlite-backend", config: ":memory:" },
+        fork: false,
+        gracefulShutdown: false,
+      });
+
+      expect(workerRuntimeMocks.start).toHaveBeenCalledTimes(1);
+      expect(fork).not.toHaveBeenCalled();
+
+      await engine.close();
+      expect(workerRuntimeMocks.shutdown).toHaveBeenCalledTimes(1);
     });
 
     sidequestTest("should warn when starting already started engine", async () => {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -13,6 +13,7 @@ import { JobBuilder, JobBuilderDefaults } from "./job/job-builder";
 import { grantQueueConfig, QueueDefaults } from "./queue/grant-queue-config";
 import { findSidequestJobsScriptInParentDirs, resolveScriptPath } from "./shared-runner";
 import { clearGracefulShutdown, gracefulShutdown } from "./utils/shutdown";
+import { WorkerRuntime } from "./workers/worker-runtime";
 
 /**
  * Configuration options for the Sidequest engine.
@@ -40,6 +41,18 @@ export interface EngineConfig {
   cleanupFinishedJobsOlderThan?: number;
   /** Whether to enable graceful shutdown handling. Defaults to `true` */
   gracefulShutdown?: boolean;
+  /**
+   * Whether to run the engine in a forked child process.
+   *
+   * - `true` (default): the engine runs in a `child_process.fork`, isolating job-code crashes from
+   *   the host application.
+   * - `false`: the engine runs in the host process. A crash in job code can take down the host, but
+   *   jobs can reach live in-process state. Useful for single-process setups (serverless, tests)
+   *   and required by framework integrations that rely on in-process execution.
+   *
+   * Defaults to `true`.
+   */
+  fork?: boolean;
   /** Minimum number of worker threads to use. Defaults to number of CPUs */
   minThreads?: number;
   /** Maximum number of worker threads to use. Defaults to `minThreads * 2` */
@@ -124,6 +137,12 @@ export class Engine {
   private mainWorker?: ChildProcess;
 
   /**
+   * Worker runtime when the engine runs in-process (`fork: false`).
+   * Mutually exclusive with {@link mainWorker}.
+   */
+  private inProcessRuntime?: WorkerRuntime;
+
+  /**
    * Flag indicating whether the engine is currently shutting down.
    * This is used to prevent multiple shutdown attempts and ensure graceful shutdown behavior.
    */
@@ -155,6 +174,7 @@ export class Engine {
         json: config?.logger?.json ?? false,
       },
       gracefulShutdown: config?.gracefulShutdown ?? true,
+      fork: config?.fork ?? true,
       minThreads: config?.minThreads ?? cpus().length,
       maxThreads: config?.maxThreads ?? cpus().length * 2,
       idleWorkerTimeout: config?.idleWorkerTimeout ?? 10_000,
@@ -241,7 +261,7 @@ export class Engine {
    * @param config Optional configuration object.
    */
   async start(config: EngineConfig): Promise<void> {
-    if (this.mainWorker) {
+    if (this.mainWorker || this.inProcessRuntime) {
       logger("Engine").warn("Sidequest engine already started");
       return;
     }
@@ -254,6 +274,14 @@ export class Engine {
       for (const queue of nonNullConfig.queues) {
         await grantQueueConfig(dependencyRegistry.get(Dependency.Backend)!, queue, nonNullConfig.queueDefaults, true);
       }
+    }
+
+    if (!nonNullConfig.fork) {
+      logger("Engine").info("Starting Sidequest in-process (fork disabled)");
+      this.inProcessRuntime = new WorkerRuntime(dependencyRegistry.get(Dependency.Backend)!, nonNullConfig);
+      await this.inProcessRuntime.start();
+      gracefulShutdown(this.close.bind(this), "Engine", nonNullConfig.gracefulShutdown);
+      return;
     }
 
     return new Promise((resolve, reject) => {
@@ -323,12 +351,16 @@ export class Engine {
         this.mainWorker.send({ type: "shutdown" });
         await promise;
       }
+      if (this.inProcessRuntime) {
+        await this.inProcessRuntime.shutdown();
+      }
       try {
         await dependencyRegistry.get(Dependency.Backend)?.close();
       } catch (error) {
         logger("Engine").error("Error closing backend:", error);
       }
       this.mainWorker = undefined;
+      this.inProcessRuntime = undefined;
       // Reset the shutting down flag after closing
       // This allows the engine to be reconfigured or restarted later
       clearGracefulShutdown();

--- a/packages/engine/src/workers/index.ts
+++ b/packages/engine/src/workers/index.ts
@@ -1,1 +1,2 @@
 export * from "./main";
+export * from "./worker-runtime";

--- a/packages/engine/src/workers/main.test.ts
+++ b/packages/engine/src/workers/main.test.ts
@@ -4,8 +4,6 @@ import { randomUUID } from "node:crypto";
 import { beforeEach, describe, expect, vi } from "vitest";
 import { Dispatcher } from "../execution/dispatcher";
 import { grantQueueConfig } from "../queue";
-import { cleanupFinishedJobs } from "../routines/cleanup-finished-job";
-import { releaseStaleJobs } from "../routines/release-stale-jobs";
 import { MainWorker } from "./main";
 
 const runMock = vi.hoisted(() => vi.fn());
@@ -20,7 +18,7 @@ vi.mock("../shared-runner", () => ({
 }));
 
 const cronMocks = vi.hoisted(() => ({
-  schedule: vi.fn().mockReturnValue({ execute: vi.fn() }),
+  schedule: vi.fn().mockReturnValue({ execute: vi.fn(), stop: vi.fn() }),
 }));
 
 vi.mock("node-cron", () => ({
@@ -60,51 +58,13 @@ describe("main.ts", () => {
     }
     await worker.runWorker(config);
     vi.resetAllMocks();
+    // resetAllMocks clears the return value, so re-establish the scheduled-task shape used by
+    // WorkerRuntime (which calls task.stop() on shutdown).
+    cronMocks.schedule.mockReturnValue({ execute: vi.fn(), stop: vi.fn() });
   });
 
   afterEach(async () => {
     await worker.shutdown();
-  });
-
-  describe("startCron", () => {
-    sidequestTest("should schedule both cron jobs", async () => {
-      await worker.startCron(60, 600_000, 60_000, 60, 0);
-
-      expect(cronMocks.schedule).toHaveBeenCalledTimes(2);
-      expect(cronMocks.schedule).toHaveBeenCalledWith("*/60 * * * *", expect.any(Function));
-    });
-
-    sidequestTest("should call releaseStaleJobs when release cron executes", async () => {
-      await worker.startCron(60, 600_000, 60_000, 60, 0);
-
-      const cronCallback = cronMocks.schedule.mock.calls[0][1] as () => unknown;
-
-      await cronCallback();
-
-      expect(releaseStaleJobs).toHaveBeenCalledWith(expect.any(Object), 600_000, 60_000);
-    });
-
-    sidequestTest("should call cleanupFinishedJobs when cleanup cron executes", async () => {
-      await worker.startCron(60, 600_000, 60_000, 60, 0);
-
-      const cronCallback = cronMocks.schedule.mock.calls[1][1] as () => unknown;
-
-      await cronCallback();
-
-      expect(cleanupFinishedJobs).toHaveBeenCalledWith(expect.any(Object), 0);
-    });
-
-    sidequestTest("should handle errors and log them when releaseStaleJobs fails", async () => {
-      const error = new Error("fail");
-      (releaseStaleJobs as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error);
-
-      await worker.startCron(60, 600_000, 60_000, 60, 0);
-
-      const cronCallback = cronMocks.schedule.mock.calls[0][1] as () => unknown;
-
-      await expect(cronCallback()).resolves.toBeUndefined();
-      expect(releaseStaleJobs).toHaveBeenCalled();
-    });
   });
 
   describe("runWorker", () => {

--- a/packages/engine/src/workers/main.ts
+++ b/packages/engine/src/workers/main.ts
@@ -1,20 +1,13 @@
-import { Backend } from "@sidequest/backend";
 import { logger } from "@sidequest/core";
-import cron from "node-cron";
 import { WORKER_PROCESS_FLAG } from "../constants";
 import { Engine, EngineConfig, NonNullableEngineConfig } from "../engine";
-import { Dispatcher } from "../execution/dispatcher";
-import { ExecutorManager } from "../execution/executor-manager";
-import { QueueManager } from "../execution/queue-manager";
-import { cleanupFinishedJobs } from "../routines/cleanup-finished-job";
-import { releaseStaleJobs } from "../routines/release-stale-jobs";
 import { gracefulShutdown } from "../utils/shutdown";
+import { WorkerRuntime } from "./worker-runtime";
 
 export class MainWorker {
   shuttingDown = false;
-  private dispatcher: Dispatcher | undefined;
+  private runtime?: WorkerRuntime;
   private engine = new Engine();
-  private backend?: Backend;
 
   /**
    * Starts a Sidequest worker process with the given configuration.
@@ -24,23 +17,8 @@ export class MainWorker {
     if (!this.shuttingDown) {
       try {
         const nonNullConfig = await this.engine.configure({ ...sidequestConfig, skipMigration: true });
-        this.backend = this.engine.getBackend()!;
-
-        this.dispatcher = new Dispatcher(
-          this.backend,
-          new QueueManager(this.backend, nonNullConfig.queues, nonNullConfig.queueDefaults),
-          new ExecutorManager(this.backend, nonNullConfig),
-          nonNullConfig.jobPollingInterval,
-        );
-        this.dispatcher.start();
-
-        await this.startCron(
-          nonNullConfig.releaseStaleJobsIntervalMin,
-          nonNullConfig.releaseStaleJobsMaxStaleMs,
-          nonNullConfig.releaseStaleJobsMaxClaimedMs,
-          nonNullConfig.cleanupFinishedJobsIntervalMin,
-          nonNullConfig.cleanupFinishedJobsOlderThan,
-        );
+        this.runtime = new WorkerRuntime(this.engine.getBackend()!, nonNullConfig);
+        await this.runtime.start();
       } catch (error) {
         logger("Worker").error(error);
         process.exit(1);
@@ -56,90 +34,12 @@ export class MainWorker {
   async shutdown() {
     if (!this.shuttingDown) {
       this.shuttingDown = true;
-      logger("Worker").debug("Shutting down dispatcher");
-      await this.dispatcher?.stop();
+      logger("Worker").debug("Shutting down worker runtime");
+      await this.runtime?.shutdown();
       logger("Worker").debug("Shutting down engine");
       await this.engine.close();
       logger("Worker").debug("Main worker completely shut down");
     }
-  }
-
-  /**
-   * Starts cron job for releasing stale jobs.
-   * Also executes the task immediately.
-   */
-  async startAndExecuteStaleJobsReleaseCron(
-    intervalMin: number,
-    maxStaleMs: number,
-    maxClaimedMs: number,
-  ): Promise<unknown> {
-    if (!this.backend) {
-      throw new Error("Backend is not initialized. Cannot start stale jobs release cron.");
-    }
-
-    logger("Worker").debug(`Starting stale jobs release cron with interval: ${intervalMin} minutes`);
-    const releaseTask = cron.schedule(`*/${intervalMin} * * * *`, async () => {
-      try {
-        logger("Worker").debug("Running stale jobs release task");
-        await releaseStaleJobs(this.backend!, maxStaleMs, maxClaimedMs);
-      } catch (error: unknown) {
-        logger("Worker").error("Error on running ReleaseStaleJob!", error);
-      }
-    });
-    return releaseTask.execute();
-  }
-
-  /**
-   * Starts cron job for cleaning up finished jobs.
-   * Also executes the task immediately.
-   */
-  async startAndExecuteFinishedJobsCleanupCron(intervalMin: number, cutoffMs: number): Promise<unknown> {
-    if (!this.backend) {
-      throw new Error("Backend is not initialized. Cannot start finished jobs cleanup cron.");
-    }
-
-    logger("Worker").debug(`Starting finished jobs cleanup cron with interval: ${intervalMin} minutes`);
-    const cleanupTask = cron.schedule(`*/${intervalMin} * * * *`, async () => {
-      try {
-        logger("Worker").debug("Running finished jobs cleanup task");
-        await cleanupFinishedJobs(this.backend!, cutoffMs);
-      } catch (error: unknown) {
-        logger("Worker").error("Error on running CleanupJob!", error);
-      }
-    });
-    return cleanupTask.execute();
-  }
-
-  /**
-   * Starts cron jobs for releasing stale jobs and cleaning up finished jobs.
-   *
-   * @param staleIntervalMin Interval in minutes for releasing stale jobs, or false to disable.
-   * @param maxStaleMs Maximum age in milliseconds for stale jobs.
-   * @param maxClaimedMs Maximum age in milliseconds for claimed jobs.
-   * @param cleanupIntervalMin Interval in minutes for cleaning up finished jobs, or false to disable
-   * @param cleanupCutoffMs Maximum age in milliseconds for finished jobs to be cleaned up.
-   */
-  async startCron(
-    staleIntervalMin: number | false,
-    maxStaleMs: number,
-    maxClaimedMs: number,
-    cleanupIntervalMin: number | false,
-    cleanupCutoffMs: number,
-  ) {
-    logger("Worker").debug("Starting cron jobs");
-    const promises: Promise<unknown>[] = [];
-
-    if (staleIntervalMin !== false) {
-      promises.push(this.startAndExecuteStaleJobsReleaseCron(staleIntervalMin, maxStaleMs, maxClaimedMs));
-    }
-
-    if (cleanupIntervalMin !== false) {
-      promises.push(this.startAndExecuteFinishedJobsCleanupCron(cleanupIntervalMin, cleanupCutoffMs));
-    }
-
-    await Promise.all(promises).catch((error) => {
-      logger("Worker").error(error);
-    });
   }
 }
 

--- a/packages/engine/src/workers/worker-runtime.test.ts
+++ b/packages/engine/src/workers/worker-runtime.test.ts
@@ -1,0 +1,119 @@
+import { sidequestTest, SidequestTestFixture } from "@/tests/fixture";
+import { beforeEach, describe, expect, vi } from "vitest";
+import { Dispatcher } from "../execution/dispatcher";
+import { cleanupFinishedJobs } from "../routines/cleanup-finished-job";
+import { releaseStaleJobs } from "../routines/release-stale-jobs";
+import { WorkerRuntime } from "./worker-runtime";
+
+const runMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../shared-runner", () => ({
+  RunnerPool: vi.fn(function () {
+    return {
+      run: runMock,
+      destroy: vi.fn(),
+    };
+  }),
+}));
+
+const cronMocks = vi.hoisted(() => ({
+  schedule: vi.fn(),
+}));
+
+vi.mock("node-cron", () => ({
+  default: {
+    schedule: cronMocks.schedule,
+  },
+}));
+
+vi.mock("../routines/cleanup-finished-job", () => ({
+  cleanupFinishedJobs: vi.fn(() => undefined),
+}));
+
+vi.mock("../routines/release-stale-jobs", () => ({
+  releaseStaleJobs: vi.fn(() => undefined),
+}));
+
+describe("WorkerRuntime", () => {
+  let runtime: WorkerRuntime;
+
+  beforeEach<SidequestTestFixture>(async ({ backend, config }) => {
+    await backend.migrate();
+    vi.clearAllMocks();
+    cronMocks.schedule.mockReturnValue({ execute: vi.fn(), stop: vi.fn() });
+    runtime = new WorkerRuntime(backend, config);
+  });
+
+  describe("start", () => {
+    sidequestTest("starts the dispatcher and schedules both cron routines", async () => {
+      const dispatcherStart = vi.spyOn(Dispatcher.prototype, "start").mockImplementation(() => undefined);
+
+      await runtime.start();
+
+      expect(dispatcherStart).toHaveBeenCalled();
+      expect(cronMocks.schedule).toHaveBeenCalledTimes(2);
+      expect(cronMocks.schedule).toHaveBeenCalledWith("*/60 * * * *", expect.any(Function));
+    });
+  });
+
+  describe("startCron", () => {
+    sidequestTest("runs releaseStaleJobs when the stale cron executes", async ({ config }) => {
+      await runtime.startCron();
+
+      const cronCallback = cronMocks.schedule.mock.calls[0][1] as () => unknown;
+      await cronCallback();
+
+      expect(releaseStaleJobs).toHaveBeenCalledWith(
+        expect.any(Object),
+        config.releaseStaleJobsMaxStaleMs,
+        config.releaseStaleJobsMaxClaimedMs,
+      );
+    });
+
+    sidequestTest("runs cleanupFinishedJobs when the cleanup cron executes", async ({ config }) => {
+      await runtime.startCron();
+
+      const cronCallback = cronMocks.schedule.mock.calls[1][1] as () => unknown;
+      await cronCallback();
+
+      expect(cleanupFinishedJobs).toHaveBeenCalledWith(expect.any(Object), config.cleanupFinishedJobsOlderThan);
+    });
+
+    sidequestTest("does not schedule routines that are disabled", async ({ backend, config }) => {
+      const disabled = new WorkerRuntime(backend, {
+        ...config,
+        releaseStaleJobsIntervalMin: false,
+        cleanupFinishedJobsIntervalMin: false,
+      });
+
+      await disabled.startCron();
+
+      expect(cronMocks.schedule).not.toHaveBeenCalled();
+    });
+
+    sidequestTest("swallows and logs errors thrown by a routine", async () => {
+      (releaseStaleJobs as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("fail"));
+
+      await runtime.startCron();
+
+      const cronCallback = cronMocks.schedule.mock.calls[0][1] as () => unknown;
+      await expect(cronCallback()).resolves.toBeUndefined();
+      expect(releaseStaleJobs).toHaveBeenCalled();
+    });
+  });
+
+  describe("shutdown", () => {
+    sidequestTest("stops the scheduled cron tasks and drains the dispatcher", async () => {
+      const stop = vi.fn();
+      cronMocks.schedule.mockReturnValue({ execute: vi.fn(), stop });
+      vi.spyOn(Dispatcher.prototype, "start").mockImplementation(() => undefined);
+      const dispatcherStop = vi.spyOn(Dispatcher.prototype, "stop").mockResolvedValue(undefined);
+
+      await runtime.start();
+      await runtime.shutdown();
+
+      expect(stop).toHaveBeenCalledTimes(2);
+      expect(dispatcherStop).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/engine/src/workers/worker-runtime.ts
+++ b/packages/engine/src/workers/worker-runtime.ts
@@ -1,0 +1,108 @@
+import { Backend } from "@sidequest/backend";
+import { logger } from "@sidequest/core";
+import cron, { ScheduledTask } from "node-cron";
+import { NonNullableEngineConfig } from "../engine";
+import { Dispatcher } from "../execution/dispatcher";
+import { ExecutorManager } from "../execution/executor-manager";
+import { QueueManager } from "../execution/queue-manager";
+import { cleanupFinishedJobs } from "../routines/cleanup-finished-job";
+import { releaseStaleJobs } from "../routines/release-stale-jobs";
+
+/**
+ * Owns the runtime side of the engine: the dispatcher loop plus the stale-job and finished-job
+ * cron routines.
+ *
+ * It runs either inside the forked worker process (driven by {@link MainWorker}) or directly in the
+ * host process when the engine is started with `fork: false`. It does NOT own the backend
+ * lifecycle: closing the backend remains the responsibility of the {@link Engine} that created it.
+ */
+export class WorkerRuntime {
+  private dispatcher: Dispatcher;
+  private cronTasks: ScheduledTask[] = [];
+
+  /**
+   * Creates a new WorkerRuntime.
+   * @param backend The backend instance.
+   * @param config The non-nullable engine configuration.
+   */
+  constructor(
+    private backend: Backend,
+    private config: NonNullableEngineConfig,
+  ) {
+    this.dispatcher = new Dispatcher(
+      backend,
+      new QueueManager(backend, config.queues, config.queueDefaults),
+      new ExecutorManager(backend, config),
+      config.jobPollingInterval,
+    );
+  }
+
+  /**
+   * Starts the dispatcher loop and the cron routines.
+   */
+  async start(): Promise<void> {
+    this.dispatcher.start();
+    await this.startCron();
+  }
+
+  /**
+   * Stops the cron routines and drains the dispatcher. Unlike the forked worker (which relies on
+   * process exit), the in-process runtime must explicitly stop its cron tasks to avoid leaks.
+   */
+  async shutdown(): Promise<void> {
+    logger("WorkerRuntime").debug("Stopping cron routines");
+    // ScheduledTask.stop() returns `void | Promise<void>`; normalize before aggregating.
+    await Promise.all(this.cronTasks.map((task) => Promise.resolve(task.stop())));
+    this.cronTasks = [];
+    logger("WorkerRuntime").debug("Stopping dispatcher");
+    await this.dispatcher.stop();
+  }
+
+  /**
+   * Schedules the stale-job and finished-job cron routines according to the config and runs each
+   * once immediately. Either routine can be disabled with a `false` interval.
+   */
+  async startCron(): Promise<void> {
+    const promises: Promise<unknown>[] = [];
+
+    if (this.config.releaseStaleJobsIntervalMin !== false) {
+      promises.push(
+        this.scheduleAndRun(this.config.releaseStaleJobsIntervalMin, "ReleaseStaleJob", () =>
+          releaseStaleJobs(
+            this.backend,
+            this.config.releaseStaleJobsMaxStaleMs,
+            this.config.releaseStaleJobsMaxClaimedMs,
+          ),
+        ),
+      );
+    }
+
+    if (this.config.cleanupFinishedJobsIntervalMin !== false) {
+      promises.push(
+        this.scheduleAndRun(this.config.cleanupFinishedJobsIntervalMin, "CleanupJob", () =>
+          cleanupFinishedJobs(this.backend, this.config.cleanupFinishedJobsOlderThan),
+        ),
+      );
+    }
+
+    await Promise.all(promises).catch((error) => logger("WorkerRuntime").error(error));
+  }
+
+  /**
+   * Schedules a recurring task at the given minute interval, tracks it for shutdown, and triggers
+   * an immediate run.
+   */
+  private scheduleAndRun(intervalMin: number, name: string, task: () => Promise<unknown>): Promise<unknown> {
+    logger("WorkerRuntime").debug(`Starting ${name} cron with interval: ${intervalMin} minutes`);
+    const scheduled = cron.schedule(`*/${intervalMin} * * * *`, async () => {
+      try {
+        logger("WorkerRuntime").debug(`Running ${name} task`);
+        await task();
+      } catch (error: unknown) {
+        logger("WorkerRuntime").error(`Error on running ${name}!`, error);
+      }
+    });
+    this.cronTasks.push(scheduled);
+    return scheduled.execute();
+  }
+}


### PR DESCRIPTION
Part of the `@sidequest/nestjs` work (PR 2b, the keystone). Targets `feat/nestjs-integration`.

## What

Adds a `fork` engine config option:
- `true` (default): the engine runs in a `child_process.fork`. No behavior change.
- `false`: the engine runs in the host process, with no fork.

## How

- Extracts the worker runtime (the dispatcher loop plus the stale-job and finished-job cron routines) out of `MainWorker` into a shared `WorkerRuntime`, used by both the forked worker and the in-process path.
- `WorkerRuntime.shutdown()` now explicitly stops its cron tasks. The forked worker relied on process exit for this; the in-process runtime must stop them itself to avoid leaks.
- `Engine.start()` runs the runtime in-process when `fork: false` (resolving immediately, no IPC handshake); `Engine.close()` tears it down before closing the backend. The backend lifecycle stays with the `Engine`, not the runtime.

## Tradeoffs (documented on the config option)

No-fork gives up crash isolation: an uncaught error in job code can take down the host process. In exchange, the engine runs in the host process, which (combined with the inline runner from PR 2a) lets jobs reach live in-process state. This is the keystone for the NestJS DI integration; it's also independently useful for serverless and single-process test setups.

## Tests

- `worker-runtime.test.ts` (new): dispatcher start, both cron routines scheduled and executed, disabled routines skipped, routine errors swallowed, and cron tasks + dispatcher stopped on shutdown.
- `main.test.ts`: updated to the refactored `MainWorker` (delegates to `WorkerRuntime`); cron-specific tests moved to `worker-runtime.test.ts`.
- `engine.test.ts`: new test asserts `fork: false` runs in-process (no `fork()` call) and `close()` shuts the runtime down.
- Full engine suite green (250 passing), lint + build + format clean.

## Note

CI does not run on PRs targeting the feature branch (workflows trigger on PRs to `master`); validated locally. Full CI runs on the eventual `feat/nestjs-integration -> master` PR.