### PR TITLE
fix: abort running job when its row no longer exists (integration hang)

### DIFF
--- a/packages/engine/src/execution/executor-manager.test.ts
+++ b/packages/engine/src/execution/executor-manager.test.ts
@@ -236,6 +236,31 @@ describe("ExecutorManager", () => {
       await executorManager.destroy();
     });
 
+    sidequestTest("aborts a running job when its row no longer exists", async ({ backend, config }) => {
+      await backend.updateJob({ ...jobData, state: "claimed", claimed_at: new Date() });
+
+      const queryConfig = await grantQueueConfig(backend, { name: "default", concurrency: 1 });
+      const executorManager = new ExecutorManager(backend, config);
+
+      // Simulate the row being deleted/truncated while the job runs: the watcher must still stop it.
+      const getJobSpy = vi.spyOn(backend, "getJob").mockResolvedValue(undefined);
+      runMock.mockImplementationOnce(
+        (_job: JobData, signal: AbortSignal) =>
+          new Promise((_, reject) => {
+            signal.addEventListener("abort", () => reject(new Error("The task has been aborted")));
+          }),
+      );
+
+      await executorManager.execute(queryConfig, jobData);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(JobTransitioner.apply).toHaveBeenCalledWith(backend, jobData, expect.any(CancelTransition));
+      expect(executorManager.totalActiveWorkers()).toBe(0);
+
+      await executorManager.destroy();
+      getJobSpy.mockRestore();
+    });
+
     sidequestTest("should abort job execution on timeout", async ({ backend, config }) => {
       jobData = await backend.updateJob({ ...jobData, state: "claimed", claimed_at: new Date(), timeout: 100 });
 

--- a/packages/engine/src/execution/executor-manager.ts
+++ b/packages/engine/src/execution/executor-manager.ts
@@ -113,11 +113,14 @@ export class ExecutorManager {
       isRunning = true;
       const cancellationCheck = async () => {
         while (isRunning) {
-          // The row can be missing transiently or if it was deleted; treat that as "not canceled"
-          // rather than dereferencing undefined and crashing the polling loop.
           const watchedJob = await this.backend.getJob(job.id);
-          if (watchedJob?.state === "canceled") {
-            logger("Executor Manager").debug(`Aborting job ${job.id}: canceled`);
+          // Abort when the job was canceled, and also when its row no longer exists (deleted or
+          // truncated): the record is gone, so the run must be stopped rather than left to block
+          // shutdown forever.
+          if (!watchedJob || watchedJob.state === "canceled") {
+            logger("Executor Manager").debug(
+              `Aborting job ${job.id}: ${watchedJob ? "canceled" : "row no longer exists"}`,
+            );
             controller.abort(new JobCanceled());
             isRunning = false;
             return;


### PR DESCRIPTION
Fixes the `integration-test` failure on #180 (25/37 tests failing).

## Root cause

The cancellation watcher in `ExecutorManager.execute` polls `backend.getJob(id)` to detect cancellation. The integration cancellation test enqueues a long, non-cooperative `TimeoutJob(1000000)`, cancels it, then in `afterEach` **truncates** the DB and calls `Sidequest.stop()`.

Once the row is truncated, `getJob` returns `undefined`, so the watcher could never see `"canceled"`. The 16-minute job was therefore never aborted, and `executorManager.destroy()` (which waits for active jobs to finish) blocked forever → `Sidequest.stop()` hung → `afterEach` hook timed out at 10s → the engine was left in a `shuttingDown` state, so every subsequent test failed with "Engine is shutting down, cannot build job."

(Before the recent `watchedJob?.state` hardening, the old `watchedJob!.state` *threw* on `undefined`, which crashed the fork and accidentally let `stop()` return. The hardening removed that crash and exposed this real gap: a running job whose row is gone is never stopped.)

## Fix

Treat a missing row the same as a cancellation in the watcher: abort the run so it stops and shutdown can proceed.

```ts
if (!watchedJob || watchedJob.state === "canceled") {
  controller.abort(new JobCanceled());
  ...
}
```

## Verification

- Full integration suite run locally against Postgres: **76/76 passing** (was hanging before).
- New unit test: a running job whose row no longer exists is aborted (CancelTransition) and freed from the active set.
- Engine suite green; lint + build + format clean.