### PR TITLE
fix: don't let a deleted job row crash the executor (CI integration flake)

### DIFF
--- a/packages/engine/src/execution/dispatcher.ts
+++ b/packages/engine/src/execution/dispatcher.ts
@@ -60,8 +60,11 @@ export class Dispatcher {
           // because the execution is not awaited. This way we ensure that available slots
           // are correctly calculated.
           this.executorManager.queueJob(queue, job);
-          // does not await for job execution.
-          void this.executorManager.execute(queue, job);
+          // does not await for job execution. Guard against any unexpected rejection so a single
+          // job can never crash the engine with an unhandled promise rejection.
+          void this.executorManager.execute(queue, job).catch((error: unknown) => {
+            logger("Dispatcher").error(`Unexpected error executing job ${job.id}:`, error);
+          });
         }
       }
 

--- a/packages/engine/src/execution/executor-manager.test.ts
+++ b/packages/engine/src/execution/executor-manager.test.ts
@@ -261,6 +261,30 @@ describe("ExecutorManager", () => {
       getJobSpy.mockRestore();
     });
 
+    sidequestTest("does not crash when the final transition fails (job row gone)", async ({ backend, config }) => {
+      const queryConfig = await grantQueueConfig(backend, { name: "default", concurrency: 1 });
+      const executorManager = new ExecutorManager(backend, config);
+
+      // RunTransition succeeds; the terminal transition fails because the row was deleted mid-run.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      vi.mocked(JobTransitioner.apply)
+        .mockImplementationOnce((_backend: Backend, job: JobData) => job)
+        .mockImplementationOnce(() => {
+          throw new Error("Cannot update job, not found.");
+        });
+      runMock.mockResolvedValue({
+        __is_job_transition__: true,
+        type: "completed",
+        result: "ok",
+      } satisfies CompletedResult);
+
+      // The fire-and-forget executor must not reject, and must free the job from the active set.
+      await expect(executorManager.execute(queryConfig, jobData)).resolves.toBeUndefined();
+      expect(executorManager.totalActiveWorkers()).toBe(0);
+
+      await executorManager.destroy();
+    });
+
     sidequestTest("should abort job execution on timeout", async ({ backend, config }) => {
       jobData = await backend.updateJob({ ...jobData, state: "claimed", claimed_at: new Date(), timeout: 100 });
 

--- a/packages/engine/src/execution/executor-manager.ts
+++ b/packages/engine/src/execution/executor-manager.ts
@@ -4,6 +4,7 @@ import {
   JobCanceled,
   JobData,
   JobTimeout,
+  JobTransition,
   JobTransitionFactory,
   logger,
   QueueConfig,
@@ -151,7 +152,7 @@ export class ExecutorManager {
       // The job ran to a conclusion and returned a state (even if a timeout/cancel was signaled);
       // respect it and transition accordingly.
       logger("Executor Manager").debug(`Job ${job.id} settled with result: ${inspect(result)}`);
-      await JobTransitioner.apply(this.backend, job, JobTransitionFactory.create(result));
+      await this.applyTerminalTransition(job, JobTransitionFactory.create(result));
     } catch (error: unknown) {
       isRunning = false;
       const err = error as Error;
@@ -162,10 +163,10 @@ export class ExecutorManager {
         const reason: unknown = controller.signal.reason;
         logger("Executor Manager").debug(`Job ${job.id} was hard-killed (${String(reason)}): ${err.message}`);
         const transition = reason instanceof JobTimeout ? new RetryTransition(reason) : new CancelTransition();
-        await JobTransitioner.apply(this.backend, job, transition);
+        await this.applyTerminalTransition(job, transition);
       } else {
         logger("Executor Manager").error(`Unhandled error while executing job ${job.id}: ${err.message}`);
-        await JobTransitioner.apply(this.backend, job, new RetryTransition(err));
+        await this.applyTerminalTransition(job, new RetryTransition(err));
       }
     } finally {
       isRunning = false;
@@ -174,6 +175,27 @@ export class ExecutorManager {
       }
       this.activeByQueue[queueConfig.name].delete(job.id);
       this.activeJobs.delete(job.id);
+    }
+  }
+
+  /**
+   * Applies a job's final transition, tolerating the job row having disappeared.
+   *
+   * A job's row can be deleted while it runs (cleanup routine, an explicit delete, or a test
+   * truncating the table). Recording its terminal state is then impossible and safe to skip. This
+   * must never throw: `execute` is fire-and-forget, so an error here would surface as an unhandled
+   * rejection.
+   *
+   * @param job The job being finalized.
+   * @param transition The terminal transition to apply.
+   */
+  private async applyTerminalTransition(job: JobData, transition: JobTransition): Promise<void> {
+    try {
+      await JobTransitioner.apply(this.backend, job, transition);
+    } catch (error) {
+      logger("Executor Manager").warn(
+        `Could not record terminal state for job ${job.id} (it may no longer exist): ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 


### PR DESCRIPTION
Fixes the intermittent `integration-test` failure on #180 ("should handle multiple scheduled jobs independently" expecting 2 executions, got 3), and the "Cannot update job, not found." error spam.

## Root cause

After #185, the cancellation watcher aborts a job when its row is gone. The catch then applies a terminal transition (`CancelTransition`), whose `updateJob` throws **"Cannot update job, not found."** on the deleted row (`sql-backend.ts:211`). Because `execute()` is fire-and-forget (`void ...execute()`), that became an **unhandled rejection**, which can crash and auto-restart the engine fork. A restart re-registers cron schedules, so a scheduled job fires an extra time, producing the "got 3, expected 2" assertion failure. Job rows are deleted in tests by the `afterEach` `truncate()`, so the race surfaces under CI timing (it passed locally where the race went the other way).

## Fix

- Route every terminal transition through `applyTerminalTransition()`, which swallows and logs failures: recording the final state of a job that no longer exists is safe to skip and must never throw.
- Guard the dispatcher's fire-and-forget `execute()` with a `.catch` so a single job can never bring the engine down with an unhandled rejection (defense in depth).

## Verification

- Integration suite run locally against Postgres **twice: 76/76 both times**, no "Cannot update job" errors, scheduled-jobs test stable.
- New unit test: `execute()` resolves (does not reject) and frees the active slot when the terminal transition fails because the row is gone.
- Engine suite green; lint + build + format clean.