### PR TITLE
fix(ci): build workspace per job instead of sharing dist via cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,5 @@
 name: Setup Project
-description: Setup Node.js, restore build cache, and setup Yarn
+description: Setup Node.js, install dependencies, and build the workspace
 
 inputs:
   node-version:
@@ -15,7 +15,12 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Restore build outputs
+    # Cache dependencies only (not build outputs). Keyed on the lockfile, so it is
+    # stable and reused across commits. Build outputs are intentionally NOT cached
+    # across jobs: every job builds its own dist below. Relying on a cross-job cache
+    # to carry **/dist proved unreliable (read-after-write inconsistency between the
+    # build job and downstream lint/test jobs left them with missing dist).
+    - name: Restore dependencies
       id: cache
       uses: actions/cache@v4
       with:
@@ -23,8 +28,7 @@ runs:
           .yarn
           node_modules
           **/node_modules
-          **/dist
-        key: ${{ runner.os }}-build-${{ hashFiles('**/yarn.lock') }}-${{ github.sha }}
+        key: ${{ runner.os }}-deps-${{ hashFiles('**/yarn.lock') }}
 
     - name: Enable Corepack
       shell: bash
@@ -33,4 +37,8 @@ runs:
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      run: yarn install --frozen-lockfile
+      run: yarn install --immutable
+
+    - name: Build workspace
+      shell: bash
+      run: yarn build


### PR DESCRIPTION
Supersedes #192 (that PR object desynced from its branch head).

## Problem

Master CI went red after merging #189/#190/#191 (all individually green, docs/metadata-only changes). The `build` job passed, but `lint`/`test`/`integration-test` failed with missing build outputs (unresolved types; `Cannot find module .../sidequest/dist/index.cjs`).

## Root cause

The `setup` action cached build outputs (`**/dist`) and the downstream jobs (which do not build) restored them via `actions/cache`. That cross-job handoff is unreliable: the `build` job saved the cache successfully, yet a `lint` job starting ~8s later got `Cache not found` for the same key (GitHub Actions cache read-after-write inconsistency, surfacing after runners were force-migrated to Node 24). A miss left the job with no `dist`.

## Fix

Stop sharing `dist` across jobs: cache dependencies only (keyed on the lockfile), and have `setup` always run `yarn build` so every job has a freshly built workspace (fast via Turbo). Also switches deprecated `--frozen-lockfile` to `--immutable`.

## Validation

This PR's CI exercises the change; merging produces a master commit whose CI uses the fix.